### PR TITLE
fix: rename module; airbyte.io -> github.com/airbytehq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ABCTL_VERSION?=dev
 .PHONY: build
 build:
-	CGO_ENABLED=0 go build -trimpath -o build/ -ldflags "-w -X airbyte.io/abctl/internal/build.Version=$(ABCTL_VERSION)" .
+	CGO_ENABLED=0 go build -trimpath -o build/ -ldflags "-w -X github.com/airbytehq/abctl/internal/build.Version=$(ABCTL_VERSION)" .
 
 .PHONY: clean
 clean:

--- a/cmd/local/local.go
+++ b/cmd/local/local.go
@@ -1,11 +1,11 @@
 package local
 
 import (
-	"airbyte.io/abctl/internal/local"
-	"airbyte.io/abctl/internal/telemetry"
 	"context"
 	"errors"
 	"fmt"
+	"github.com/airbytehq/abctl/internal/local"
+	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/pterm/pterm"
 	"os"
 	"path/filepath"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
-	"airbyte.io/abctl/cmd/local"
-	"airbyte.io/abctl/cmd/version"
-	localcmd "airbyte.io/abctl/internal/local"
 	"errors"
+	"github.com/airbytehq/abctl/cmd/local"
+	"github.com/airbytehq/abctl/cmd/version"
+	localcmd "github.com/airbytehq/abctl/internal/local"
 	"github.com/pterm/pterm"
 	"os"
 

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 import (
-	"airbyte.io/abctl/internal/build"
+	"github.com/airbytehq/abctl/internal/build"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -1,9 +1,9 @@
 package version
 
 import (
-	"airbyte.io/abctl/internal/build"
 	"bytes"
 	"fmt"
+	"github.com/airbytehq/abctl/internal/build"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pterm/pterm"
 	"os"

--- a/create-release-builds
+++ b/create-release-builds
@@ -48,7 +48,7 @@ abbuild() {
   local goarch=$2
   local compress=$3
   echo " - $goos/$goarch"
-  GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 go build -trimpath -o "$release_dir/abctl-$ABCTL_VERSION-$goos-$goarch/" -ldflags "-w -X airbyte.io/abctl/internal/build.Version=${ABCTL_VERSION}" .
+  GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 go build -trimpath -o "$release_dir/abctl-$ABCTL_VERSION-$goos-$goarch/" -ldflags "-w -X github.com/airbytehq/abctl/internal/build.Version=${ABCTL_VERSION}" .
   eval $compress "$goos" "$goarch"
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module airbyte.io/abctl
+module github.com/airbytehq/abctl
 
 go 1.21.9
 

--- a/internal/local/cmd.go
+++ b/internal/local/cmd.go
@@ -1,10 +1,10 @@
 package local
 
 import (
-	"airbyte.io/abctl/internal/telemetry"
 	"context"
 	"errors"
 	"fmt"
+	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	helmclient "github.com/mittwald/go-helm-client"

--- a/internal/local/cmd_test.go
+++ b/internal/local/cmd_test.go
@@ -1,9 +1,9 @@
 package local
 
 import (
-	"airbyte.io/abctl/internal/telemetry"
 	"context"
 	"errors"
+	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/docker/docker/api/types"
 	"github.com/google/go-cmp/cmp"
 	helmclient "github.com/mittwald/go-helm-client"

--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -1,9 +1,9 @@
 package telemetry
 
 import (
-	"airbyte.io/abctl/internal/build"
 	"bytes"
 	"fmt"
+	"github.com/airbytehq/abctl/internal/build"
 	"github.com/oklog/ulid/v2"
 	"github.com/pbnjay/memory"
 	"k8s.io/apimachinery/pkg/util/json"

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"airbyte.io/abctl/cmd"
+	"github.com/airbytehq/abctl/cmd"
 )
 
 func main() {


### PR DESCRIPTION
- rename module `airbyte.io` -> `github.com/airbytehq`
    - fix `go install` issues 