### PR TITLE
fix: error format and extra whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
+<p align="center">
+    <img alt="abctl logo" src="https://avatars.githubusercontent.com/u/59758427?size=200" height="140" />
+    <h3 align="center">abctl</h3>
+    <p align="center">Airbyte command line tool for running Airbyte locally.</p>
+</p>
+
+---
+
+
 # abctl
+
 
 ## Getting Started
 

--- a/cmd/local/local.go
+++ b/cmd/local/local.go
@@ -89,16 +89,16 @@ var UninstallCmd = &cobra.Command{
 // telemetryWrapper wraps the function calls with the telemetry handlers
 func telemetryWrapper(et telemetry.EventType, f func() error) (err error) {
 	if err := telClient.Start(et); err != nil {
-		pterm.Warning.Println("unable to send telemetry start data: %w", err)
+		pterm.Warning.Printfln("unable to send telemetry start data: %s", err)
 	}
 	defer func() {
 		if err != nil {
 			if err := telClient.Failure(et, err); err != nil {
-				pterm.Warning.Println("unable to send telemetry failure data: %w", err)
+				pterm.Warning.Printfln("unable to send telemetry failure data: %s", err)
 			}
 		} else {
 			if err := telClient.Success(et); err != nil {
-				pterm.Warning.Println("unable to send telemetry success data: %w", err)
+				pterm.Warning.Printfln("unable to send telemetry success data: %s", err)
 			}
 		}
 	}()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,7 @@ var (
 	// rootCmd represents the base command when called without any subcommands
 	rootCmd = &cobra.Command{
 		Use:   "abctl",
-		Short: pterm.LightBlue("Airbyte") + "'s  command line tool",
+		Short: pterm.LightBlue("Airbyte") + "'s command line tool",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if flagDNT {
 				pterm.Info.Println("telemetry disabled (--dnt)")


### PR DESCRIPTION
- fix telemetry errors being output with the wrong format - %w -> %s
- remove extra whitespace