### PR TITLE
feat: add BuildInfo support

### DIFF
--- a/internal/build/info.go
+++ b/internal/build/info.go
@@ -3,22 +3,47 @@ package build
 import (
 	"fmt"
 	"golang.org/x/mod/semver"
+	"runtime/debug"
 	"strings"
 )
 
 // Version is the build of this tool.
-// The expectation is that this will be set during build time via ldflags.
+// The expectation is that this will be set during build time via ldflags or via the BuildInfo if "go install"ed.
 // Supported values: "dev", any semver (with or without a 'v', if no 'v' exists, one will be added).
-// Any invalid versions will be replaced with "invalid (BAD_VERSION)".
+// Any invalid version will be replaced with "invalid (BAD_VERSION)".
 var Version = "dev"
 
-func init() {
+// buildInfoFunc matches the debug.ReadBuildInfo method, redefined here for testing purposes.
+type buildInfoFunc func() (*debug.BuildInfo, bool)
+
+// readBuildInfo is a function pointer to debug.ReadBuildInfo, defined here for testing purposes.
+var readBuildInfo buildInfoFunc = debug.ReadBuildInfo
+
+// setVersion sets the Version variable correctly.
+// This method is only separated out from the init method for testing purposes and should only
+// be called by init and the unit tests.
+func setVersion() {
+	fmt.Println("init called")
+	if Version == "dev" {
+		buildInfo, ok := readBuildInfo()
+		if ok {
+			if buildInfo.Main.Version != "" {
+				Version = buildInfo.Main.Version
+			}
+		}
+	}
+
 	if Version != "dev" {
+		origVersion := Version
 		if !strings.HasPrefix(Version, "v") {
 			Version = "v" + Version
 		}
 		if !semver.IsValid(Version) {
-			Version = fmt.Sprintf("invalid (%s)", Version)
+			Version = fmt.Sprintf("invalid (%s)", origVersion)
 		}
 	}
+}
+
+func init() {
+	setVersion()
 }

--- a/internal/build/info_test.go
+++ b/internal/build/info_test.go
@@ -1,0 +1,108 @@
+package build
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"runtime/debug"
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	// struct definition
+	// name: name of the sub-test
+	// buildInfoFunc: test function to replace the default readBuildInfo function pointer
+	// versionFunc: test function for updating the default Version value
+	// exp: expected value that Version should be at the end
+	tests := []struct {
+		name          string
+		versionFunc   func()
+		buildInfoFunc buildInfoFunc
+		exp           string
+	}{
+		{
+			name: "default",
+			exp:  "dev",
+		},
+		{
+			name:        "no v prefix",
+			versionFunc: func() { Version = "9.8.7" },
+			exp:         "v9.8.7",
+		},
+		{
+			name:        "v prefix",
+			versionFunc: func() { Version = "v3.1.4" },
+			exp:         "v3.1.4",
+		},
+		{
+			name:          "non-ok BuildInfo",
+			buildInfoFunc: func() (*debug.BuildInfo, bool) { return nil, false },
+			exp:           "dev",
+		},
+		{
+			name:        "version non-dev, BuildInfo ignored",
+			versionFunc: func() { Version = "5.5.5" },
+			buildInfoFunc: func() (*debug.BuildInfo, bool) {
+				return &debug.BuildInfo{Main: debug.Module{
+					Version: "v9.9.9",
+				}}, true
+			},
+			exp: "v5.5.5",
+		},
+		{
+			name: "version dev, BuildInfo honored",
+			buildInfoFunc: func() (*debug.BuildInfo, bool) {
+				return &debug.BuildInfo{Main: debug.Module{
+					Version: "v9.9.9",
+				}}, true
+			},
+			exp: "v9.9.9",
+		},
+		{
+			name:        "invalid version defined",
+			versionFunc: func() { Version = "bad.version" },
+			exp:         "invalid (bad.version)",
+		},
+		{
+			name: "invalid version from buildInfo",
+			buildInfoFunc: func() (*debug.BuildInfo, bool) {
+				return &debug.BuildInfo{Main: debug.Module{
+					Version: "BAD_BUILD",
+				}}, true
+			},
+			exp: "invalid (BAD_BUILD)",
+		},
+		{
+			name:        "invalid version defined with v",
+			versionFunc: func() { Version = "vbad.version" },
+			exp:         "invalid (vbad.version)",
+		},
+		{
+			name: "invalid version from buildInfo with v",
+			buildInfoFunc: func() (*debug.BuildInfo, bool) {
+				return &debug.BuildInfo{Main: debug.Module{
+					Version: "VBAD_BUILD",
+				}}, true
+			},
+			exp: "invalid (VBAD_BUILD)",
+		},
+	}
+
+	origReadBuildInfo := readBuildInfo
+	origVersion := Version
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(func() { readBuildInfo = origReadBuildInfo })
+			if tt.buildInfoFunc != nil {
+				readBuildInfo = tt.buildInfoFunc
+				Version = origVersion
+			}
+			if tt.versionFunc != nil {
+				tt.versionFunc()
+			}
+			setVersion()
+
+			if d := cmp.Diff(tt.exp, Version); d != "" {
+				t.Error("Version differed (-want, +got):", d)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If installed via `go install` the `build.Version` will not be set correctly and will default to `dev`.  The change will now attempt to set the `build.Version` to the `BuildInfo.Main.Version` in that situation.