### PR TITLE
feat: improve version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ clean:
 fmt:
 	go fmt ./...
 
+.PHONY: test
+test:
+	go test ./...
+
 .PHONY: vet
 vet:
 	go vet ./...

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -10,8 +10,11 @@ import (
 // The version information is read directly from build.Version.
 var Cmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print the version number",
+	Short: "Print version information",
 	Run: func(cmd *cobra.Command, args []string) {
-		pterm.Printfln("version: %s", build.Version)
+		pterm.Printfln(`version: %s
+revision: %s
+time: %s
+modified: %t`, build.Version, build.Revision, build.ModificationTime, build.Modified)
 	},
 }

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -21,27 +21,37 @@ func TestCmd_Output(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if d := cmp.Diff(fmt.Sprintf("version: %s\n", build.Version), b.String()); d != "" {
+	exp := fmt.Sprintf("version: %s\nrevision: %s\ntime: %s\nmodified: %t\n", build.Version, build.Revision, build.ModificationTime, build.Modified)
+
+	if d := cmp.Diff(exp, b.String()); d != "" {
 		t.Error("cmd mismatch (-want +got):\n", d)
 	}
 }
 
-func TestCmd_OutputVersionOverride(t *testing.T) {
+func TestCmd_OutputOverride(t *testing.T) {
 	origVersion := build.Version
 	build.Version = "v12.15.82"
+	build.Revision = "revision"
+	build.Modified = true
+	build.ModificationTime = "20240401T00:00:00Z"
 	b := bytes.NewBufferString("")
 	pterm.SetDefaultOutput(b)
 
 	t.Cleanup(func() {
 		pterm.SetDefaultOutput(os.Stdout)
 		build.Version = origVersion
+		build.Revision = ""
+		build.Modified = false
+		build.ModificationTime = ""
 	})
+
+	exp := fmt.Sprintf("version: %s\nrevision: %s\ntime: %s\nmodified: %t\n", build.Version, build.Revision, build.ModificationTime, build.Modified)
 
 	if err := Cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
 
-	if d := cmp.Diff(fmt.Sprintf("version: %s\n", build.Version), b.String()); d != "" {
+	if d := cmp.Diff(exp, b.String()); d != "" {
 		t.Error("cmd mismatch (-want +got):\n", d)
 	}
 }

--- a/internal/build/info.go
+++ b/internal/build/info.go
@@ -26,7 +26,7 @@ func setVersion() {
 	if Version == "dev" {
 		buildInfo, ok := readBuildInfo()
 		if ok {
-			if buildInfo.Main.Version != "" {
+			if buildInfo.Main.Version != "" && buildInfo.Main.Version != "(devel)" {
 				Version = buildInfo.Main.Version
 			}
 		}

--- a/internal/build/info.go
+++ b/internal/build/info.go
@@ -13,6 +13,18 @@ import (
 // Any invalid version will be replaced with "invalid (BAD_VERSION)".
 var Version = "dev"
 
+// Revision is the git hash which built this tool.
+// This value is automatically set if the buildInfoFunc function returns the "vcs.revision" setting.
+var Revision string
+
+// Modified is true if there are local code modifications when this binary was built.
+// This value is automatically set if the buildInfoFunc function returns the "vcs.modified" setting.
+var Modified bool
+
+// ModificationTime is the time, in RFC3339 format, of this binary.
+// This value is automatically set fi the buildInfoFunc function returns the "vcs.time" settings.
+var ModificationTime string
+
 // buildInfoFunc matches the debug.ReadBuildInfo method, redefined here for testing purposes.
 type buildInfoFunc func() (*debug.BuildInfo, bool)
 
@@ -28,6 +40,16 @@ func setVersion() {
 		if ok {
 			if buildInfo.Main.Version != "" && buildInfo.Main.Version != "(devel)" {
 				Version = buildInfo.Main.Version
+			}
+			for _, kv := range buildInfo.Settings {
+				switch kv.Key {
+				case "vcs.modified":
+					Modified = kv.Value == "true"
+				case "vcs.time":
+					ModificationTime = kv.Value
+				case "vcs.revision":
+					Revision = kv.Value
+				}
 			}
 		}
 	}

--- a/internal/build/info_test.go
+++ b/internal/build/info_test.go
@@ -84,6 +84,15 @@ func TestVersion(t *testing.T) {
 			},
 			exp: "invalid (VBAD_BUILD)",
 		},
+		{
+			name: "(devel) version is ignored",
+			buildInfoFunc: func() (*debug.BuildInfo, bool) {
+				return &debug.BuildInfo{Main: debug.Module{
+					Version: "(devel)",
+				}}, true
+			},
+			exp: "dev",
+		},
 	}
 
 	origReadBuildInfo := readBuildInfo


### PR DESCRIPTION
- ignore the `debug.ReadBuildInfo` value of `(devel)`
- add the following additional version information to the `version` command
    - revision - the git has that was built
    - time (of last modification) - the time associated with that git hash (or the last modification)
    - modified - true if this build contains modified files not part of version control
- add make `test` target