### PR TITLE
fix: update error messaging for docker and kubernetes specific failures

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,9 +11,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// dockerHelp is displayed if ErrDocker is ever returned
-const dockerHelp = `An error occurred while communicating with the Docker daemon.
-Ensure that Docker is running and is accessible.  You may need to upgrade to a newer version of Docker.`
+// Help messages to display for specific error situations.
+const (
+	// helpDocker is displayed if ErrDocker is ever returned
+	helpDocker = `An error occurred while communicating with the Docker daemon.
+Ensure that Docker is running and is accessible.  You may need to upgrade to a newer version of Docker.
+For additional help please visit https://docs.docker.com/get-docker/`
+
+	// helpKubernetes is displayed if ErrKubernetes is ever returned
+	helpKubernetes = `An error occurred while communicating with the Kubernetes cluster.
+If using Docker Desktop, ensure that Kubernetes is enabled.
+For additional help please visit https://docs.docker.com/desktop/kubernetes/`
+)
 
 var (
 	// flagDNT indicates if the do-not-track flag was specified
@@ -39,7 +48,10 @@ func Execute() {
 
 		if errors.Is(err, localcmd.ErrDocker) {
 			pterm.Println()
-			pterm.Info.Println(dockerHelp)
+			pterm.Info.Println(helpDocker)
+		} else if errors.Is(err, localcmd.ErrKubernetes) {
+			pterm.Println()
+			pterm.Info.Println(helpKubernetes)
 		}
 		os.Exit(1)
 	}

--- a/internal/local/cmd.go
+++ b/internal/local/cmd.go
@@ -64,7 +64,7 @@ type HTTPClient interface {
 // BrowserLauncher primarily for testing purposes.
 type BrowserLauncher func(url string) error
 
-// Errors related to specific systems that this integrations with.
+// Errors related to specific systems that this code integrates with.
 var (
 	// ErrDocker is returned anytime an error occurs when attempting to communicate with docker.
 	ErrDocker = errors.New("error communicating with docker")

--- a/internal/local/cmd.go
+++ b/internal/local/cmd.go
@@ -61,11 +61,17 @@ type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// BrowserLauncher for
+// BrowserLauncher primarily for testing purposes.
 type BrowserLauncher func(url string) error
 
-// ErrDocker is returned anytime an error specific to docker occurs.
-var ErrDocker = errors.New("error communicating with docker")
+// Errors related to specific systems that this integrations with.
+var (
+	// ErrDocker is returned anytime an error occurs when attempting to communicate with docker.
+	ErrDocker = errors.New("error communicating with docker")
+
+	// ErrKubernetes is returned anytime an error occurs when attempting to communicate with the kubernetes cluster
+	ErrKubernetes = errors.New("error communicating with kubernetes")
+)
 
 // DockerClient primarily for testing purposes
 type DockerClient interface {
@@ -175,16 +181,17 @@ func New(opts ...Option) (*Command, error) {
 	if c.k8s == nil {
 		k8sCfg, err := k8sClientConfig(c.userHome)
 		if err != nil {
-			return nil, fmt.Errorf("could not create k8s client config: %w", err)
+			return nil, fmt.Errorf("%w: %w", ErrKubernetes, err)
 		}
 
 		restCfg, err := k8sCfg.ClientConfig()
 		if err != nil {
-			return nil, fmt.Errorf("could not create k8s config client: %w", err)
+			return nil, fmt.Errorf("%w: could not create rest config: %w", ErrKubernetes, err)
 		}
+
 		k8s, err := kubernetes.NewForConfig(restCfg)
 		if err != nil {
-			return nil, fmt.Errorf("could not create k8s client: %w", err)
+			return nil, fmt.Errorf("%w: could not create clientset: %w", ErrKubernetes, err)
 		}
 
 		c.k8s = &defaultK8sClient{k8s: k8s}
@@ -207,7 +214,7 @@ func New(opts ...Option) (*Command, error) {
 			RestConfig: restCfg,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("coud not create helm client: %w", err)
+			return nil, fmt.Errorf("could not create helm client: %w", err)
 		}
 
 		c.helm = helm
@@ -237,7 +244,7 @@ func New(opts ...Option) (*Command, error) {
 	{
 		k8sVersion, err := c.k8s.GetServerVersion()
 		if err != nil {
-			return nil, fmt.Errorf("could not fetch k8s server version: %w", err)
+			return nil, fmt.Errorf("%w: could not fetch kubernetes server version: %w", ErrKubernetes, err)
 		}
 		c.tel.Attr("k8s_version", k8sVersion)
 	}


### PR DESCRIPTION
- add a `ErrKubernetes` error that will be returned if an error occurs while attempting to communicate with the kubernetes cluster
- add help message that is displayed if `ErrKubernetes` is returned
- improve help message that is deplayed if `ErrDocker` is returned