### PR TITLE
fix: capture version as both `build` and `script_version`

### DIFF
--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -61,6 +61,7 @@ func (s *SegmentClient) send(es EventState, et EventType, ee error) error {
 		"state":             string(es),
 		"os":                runtime.GOOS,
 		"build":             build.Version,
+		"script_version":    build.Version,
 		"cpu_count":         strconv.Itoa(runtime.NumCPU()),
 		"mem_total_bytes":   strconv.FormatUint(memory.TotalMemory(), 10),
 		"mem_free_bytes":    strconv.FormatUint(memory.FreeMemory(), 10),


### PR DESCRIPTION
Publish the `build` version as both `build` and `script_version` to align with what [run-ab-platform](https://github.com/airbytehq/airbyte/blob/bc7b4cb44c8727929eb4fedd36cb9fb9dea38a27/run-ab-platform.sh#L161C6-L161C20) does.