### PR TITLE
fix: docker check on osx incorrectly failing

### DIFF
--- a/internal/cmd/local/check.go
+++ b/internal/cmd/local/check.go
@@ -23,7 +23,7 @@ var dockerClient *docker.Docker
 func dockerInstalled(ctx context.Context) (docker.Version, error) {
 	var err error
 	if dockerClient == nil {
-		if dockerClient, err = docker.New(); err != nil {
+		if dockerClient, err = docker.New(ctx); err != nil {
 			pterm.Error.Println("Could not create Docker client")
 			return docker.Version{}, fmt.Errorf("%w: could not create client: %w", localerr.ErrDocker, err)
 		}

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -62,7 +62,7 @@ func NewCmdInstall() *cobra.Command {
 					// only for kind do we need to check the existing port
 					if provider.Name == k8s.Kind {
 						if dockerClient == nil {
-							dockerClient, err = docker.New()
+							dockerClient, err = docker.New(cmd.Context())
 							if err != nil {
 								pterm.Error.Printfln("Could not connect to Docker daemon")
 								return fmt.Errorf("could not connect to docker: %w", err)

--- a/internal/local/cmd.go
+++ b/internal/local/cmd.go
@@ -582,7 +582,7 @@ func defaultHelm(kubecfg, kubectx string) (HelmClient, error) {
 		RestConfig: restCfg,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("coud not create helm client: %w", err)
+		return nil, fmt.Errorf("could not create helm client: %w", err)
 	}
 
 	return helm, nil


### PR DESCRIPTION
- on osx, don't fail the docker check if the second attempt is successful
    - On osx, docker can be communicated with via `/var/run/docker.sock` or `~/.docker/run/docker.sock`.  The existing code was incorrectly failing this check if the second attempt (`~/.docker/run/docker.sock`) was successful.
- fix typo in error messages - `coud` -> `could`
- add `context` to `docker.New` call
- call `Ping` on the docker client before marking the client creation as successful
    - Fix an issue where the client would be created but would fail when communicating with it at a later step.  This early `Ping` check establishes that we can communicate with the docker daemon before we consider our client successfully created.