### PR TITLE
fix: warning log formatting

### DIFF
--- a/internal/cmd/local/k8s/client.go
+++ b/internal/cmd/local/k8s/client.go
@@ -128,7 +128,7 @@ func (d *DefaultK8sClient) EventsWatch(ctx context.Context, namespace string) (w
 }
 
 func (d *DefaultK8sClient) LogsGet(ctx context.Context, namespace string, name string) (string, error) {
-	req := d.ClientSet.CoreV1().Pods(namespace).GetLogs(name, &coreV1.PodLogOptions{Previous: true})
+	req := d.ClientSet.CoreV1().Pods(namespace).GetLogs(name, &coreV1.PodLogOptions{})
 	reader, err := req.Stream(ctx)
 	if err != nil {
 		return "", fmt.Errorf("could not get logs for pod %s: %w", name, err)

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -358,7 +358,7 @@ func (c *Command) handleEvent(ctx context.Context, e *v1events.Event) {
 		if logs != "" {
 			pterm.Warning.Printfln(
 				"Encountered an issue deploying Airbyte:\n  Pod: %s\n  Reason: %s\n  Message: %s\n  Count: %d\n  Logs: %s",
-				e.Name, e.Reason, e.Note, e.DeprecatedCount, logs,
+				e.Name, e.Reason, e.Note, e.DeprecatedCount, strings.TrimSpace(logs),
 			)
 		} else {
 			pterm.Warning.Printfln(


### PR DESCRIPTION
- trim whitespace from log messages
    - this removes the double-newline at the end of the warning message
- fetch the current pod logs, not the previous 