### PR TITLE
feat: set env-var `AIRBYTE_INSTALLATION_ID`

### DIFF
--- a/internal/cmd/local/check_test.go
+++ b/internal/cmd/local/check_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/docker/docker/api/types"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"net"
 	"strconv"
 	"strings"
@@ -133,6 +134,7 @@ type mockTelemetryClient struct {
 	success func(ctx context.Context, eventType telemetry.EventType) error
 	failure func(ctx context.Context, eventType telemetry.EventType, err error) error
 	attr    func(key, val string)
+	user    func() uuid.UUID
 }
 
 func (m *mockTelemetryClient) Start(ctx context.Context, eventType telemetry.EventType) error {
@@ -149,4 +151,8 @@ func (m *mockTelemetryClient) Failure(ctx context.Context, eventType telemetry.E
 
 func (m *mockTelemetryClient) Attr(key, val string) {
 	m.attr(key, val)
+}
+
+func (m *mockTelemetryClient) User() uuid.UUID {
+	return m.user()
 }

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/airbytehq/abctl/internal/cmd/local/localerr"
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/cli/browser"
+	"github.com/google/uuid"
 	helmclient "github.com/mittwald/go-helm-client"
 	"github.com/mittwald/go-helm-client/values"
 	"github.com/pterm/pterm"
@@ -223,6 +224,12 @@ func New(provider k8s.Provider, opts ...Option) (*Command, error) {
 func (c *Command) Install(ctx context.Context, user, pass string) error {
 	go c.watchEvents(ctx)
 
+	var telUser string
+	// only override the empty telUser if the tel.User returns a non-nil (uuid.Nil) value.
+	if c.tel.User() != uuid.Nil {
+		telUser = c.tel.User().String()
+	}
+
 	if err := c.handleChart(ctx, chartRequest{
 		name:         "airbyte",
 		repoName:     airbyteRepoName,
@@ -231,7 +238,7 @@ func (c *Command) Install(ctx context.Context, user, pass string) error {
 		chartRelease: airbyteChartRelease,
 		chartVersion: c.helmChartVersion,
 		namespace:    airbyteNamespace,
-		values:       []string{fmt.Sprintf("global.env_vars.AIRBYTE_INSTALLATION_ID=%s", "")},
+		values:       []string{fmt.Sprintf("global.env_vars.AIRBYTE_INSTALLATION_ID=%s", telUser)},
 	}); err != nil {
 		return fmt.Errorf("could not install airbyte chart: %w", err)
 	}

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -231,6 +231,7 @@ func (c *Command) Install(ctx context.Context, user, pass string) error {
 		chartRelease: airbyteChartRelease,
 		chartVersion: c.helmChartVersion,
 		namespace:    airbyteNamespace,
+		values:       []string{fmt.Sprintf("global.env_vars.AIRBYTE_INSTALLATION_ID=%s", "")},
 	}); err != nil {
 		return fmt.Errorf("could not install airbyte chart: %w", err)
 	}

--- a/internal/cmd/local/local/cmd_test.go
+++ b/internal/cmd/local/local/cmd_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	helmclient "github.com/mittwald/go-helm-client"
 	"github.com/mittwald/go-helm-client/values"
 	"helm.sh/helm/v3/pkg/action"
@@ -256,6 +257,7 @@ type mockTelemetryClient struct {
 	success func(context.Context, telemetry.EventType) error
 	failure func(context.Context, telemetry.EventType, error) error
 	attr    func(key, val string)
+	user    func() uuid.UUID
 }
 
 func (m *mockTelemetryClient) Start(ctx context.Context, eventType telemetry.EventType) error {
@@ -272,6 +274,10 @@ func (m *mockTelemetryClient) Failure(ctx context.Context, eventType telemetry.E
 
 func (m *mockTelemetryClient) Attr(key, val string) {
 	m.attr(key, val)
+}
+
+func (m *mockTelemetryClient) User() uuid.UUID {
+	return m.user()
 }
 
 var _ HTTPClient = (*mockHTTP)(nil)

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/pterm/pterm"
 	"net/http"
 	"os"
@@ -36,6 +37,8 @@ type Client interface {
 	Failure(context.Context, EventType, error) error
 	// Attr should be called to add additional attributes to this activity.
 	Attr(key, val string)
+	// User returns the user identifier being used by this client
+	User() uuid.UUID
 }
 
 type getConfig struct {

--- a/internal/telemetry/config.go
+++ b/internal/telemetry/config.go
@@ -27,7 +27,7 @@ func NewUUID() UUID {
 
 // String returns a string representation of this UUID.
 func (u UUID) String() string {
-	return u.ToUUID().String()
+	return u.toUUID().String()
 }
 
 func (u *UUID) UnmarshalYAML(node *yaml.Node) error {
@@ -46,7 +46,7 @@ func (u *UUID) UnmarshalYAML(node *yaml.Node) error {
 }
 
 func (u UUID) MarshalYAML() (any, error) {
-	return uuid.UUID(u).String(), nil
+	return u.toUUID().String(), nil
 }
 
 // IsZero implements the yaml interface, used to treat a uuid.Nil as empty for yaml purposes
@@ -54,7 +54,8 @@ func (u UUID) IsZero() bool {
 	return u.String() == uuid.Nil.String()
 }
 
-func (u UUID) ToUUID() uuid.UUID {
+// toUUID converts the telemetry.UUID type back to the underlying uuid.UUID type
+func (u UUID) toUUID() uuid.UUID {
 	return uuid.UUID(u)
 }
 

--- a/internal/telemetry/config.go
+++ b/internal/telemetry/config.go
@@ -27,7 +27,7 @@ func NewUUID() UUID {
 
 // String returns a string representation of this UUID.
 func (u UUID) String() string {
-	return uuid.UUID(u).String()
+	return u.ToUUID().String()
 }
 
 func (u *UUID) UnmarshalYAML(node *yaml.Node) error {
@@ -52,6 +52,10 @@ func (u UUID) MarshalYAML() (any, error) {
 // IsZero implements the yaml interface, used to treat a uuid.Nil as empty for yaml purposes
 func (u UUID) IsZero() bool {
 	return u.String() == uuid.Nil.String()
+}
+
+func (u UUID) ToUUID() uuid.UUID {
+	return uuid.UUID(u)
 }
 
 // ULID is a wrapper around ulid.ULID so that we can implement the yaml interfaces.

--- a/internal/telemetry/config_test.go
+++ b/internal/telemetry/config_test.go
@@ -230,7 +230,7 @@ anonymous_user_uuid: %s
 
 func TestUUID(t *testing.T) {
 	t.Run("string", func(t *testing.T) {
-		uuid := uuid.New()
+		uuid := NewUUID()
 		if d := cmp.Diff(36, len(uuid.String())); d != "" {
 			t.Error("uuid length mismatch", d)
 		}
@@ -267,6 +267,13 @@ func TestUUID(t *testing.T) {
 		uuid = NewUUID()
 		if d := cmp.Diff(false, uuid.IsZero()); d != "" {
 			t.Error("uuid should zero", d)
+		}
+	})
+
+	t.Run("ToUUID", func(t *testing.T) {
+		uuid := NewUUID()
+		if d := cmp.Diff(36, len(uuid.ToUUID())); d != "" {
+			t.Error("uuid length mismatch", d)
 		}
 	})
 }

--- a/internal/telemetry/config_test.go
+++ b/internal/telemetry/config_test.go
@@ -272,7 +272,7 @@ func TestUUID(t *testing.T) {
 
 	t.Run("ToUUID", func(t *testing.T) {
 		uuid := NewUUID()
-		if d := cmp.Diff(36, len(uuid.ToUUID())); d != "" {
+		if d := cmp.Diff(36, len(uuid.ToUUID().String())); d != "" {
 			t.Error("uuid length mismatch", d)
 		}
 	})

--- a/internal/telemetry/config_test.go
+++ b/internal/telemetry/config_test.go
@@ -270,9 +270,9 @@ func TestUUID(t *testing.T) {
 		}
 	})
 
-	t.Run("ToUUID", func(t *testing.T) {
+	t.Run("toUUID", func(t *testing.T) {
 		uuid := NewUUID()
-		if d := cmp.Diff(36, len(uuid.ToUUID().String())); d != "" {
+		if d := cmp.Diff(36, len(uuid.toUUID().String())); d != "" {
 			t.Error("uuid length mismatch", d)
 		}
 	})

--- a/internal/telemetry/noop.go
+++ b/internal/telemetry/noop.go
@@ -1,6 +1,9 @@
 package telemetry
 
-import "context"
+import (
+	"context"
+	"github.com/google/uuid"
+)
 
 var _ Client = (*NoopClient)(nil)
 
@@ -21,3 +24,7 @@ func (n NoopClient) Failure(context.Context, EventType, error) error {
 }
 
 func (n NoopClient) Attr(_, _ string) {}
+
+func (n NoopClient) User() uuid.UUID {
+	return uuid.Nil
+}

--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -39,6 +39,8 @@ func WithSessionID(sessionID uuid.UUID) Option {
 	}
 }
 
+var _ Client = (*SegmentClient)(nil)
+
 // SegmentClient client, all methods communicate with segment.
 type SegmentClient struct {
 	doer      Doer
@@ -76,6 +78,10 @@ func (s *SegmentClient) Failure(ctx context.Context, et EventType, err error) er
 
 func (s *SegmentClient) Attr(key, val string) {
 	s.attrs[key] = val
+}
+
+func (s *SegmentClient) User() uuid.UUID {
+	return s.cfg.UserUUID.ToUUID()
 }
 
 const (

--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -81,7 +81,7 @@ func (s *SegmentClient) Attr(key, val string) {
 }
 
 func (s *SegmentClient) User() uuid.UUID {
-	return s.cfg.UserUUID.ToUUID()
+	return s.cfg.UserUUID.toUUID()
 }
 
 const (

--- a/internal/telemetry/wrapper_test.go
+++ b/internal/telemetry/wrapper_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
 	"github.com/pterm/pterm"
 	"os"
 	"strings"
@@ -203,6 +204,7 @@ type MockClient struct {
 	success func(ctx context.Context, eventType EventType) error
 	failure func(ctx context.Context, eventType EventType, err error) error
 	attr    func(key, val string)
+	user    func() uuid.UUID
 }
 
 func (m MockClient) Start(ctx context.Context, eventType EventType) error {
@@ -219,4 +221,8 @@ func (m MockClient) Failure(ctx context.Context, eventType EventType, err error)
 
 func (m MockClient) Attr(key, val string) {
 	m.attr(key, val)
+}
+
+func (m MockClient) User() uuid.UUID {
+	return m.user()
 }


### PR DESCRIPTION
- set `ARIBYTE_INSTALLATION_ID` env-var via helm
   - `global.env_vars.AIRBYTE_INSTALLATION_ID=[user]`
- add `User` method to `telemetry.Client`
    - this represents the user-id (a `uuid`) for telemetry purposes 