### PR TITLE
feat: add `--values` flag to `local install` command

### DIFF
--- a/internal/cmd/local/local/cmd_test.go
+++ b/internal/cmd/local/local/cmd_test.go
@@ -18,6 +18,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 )
@@ -155,9 +156,175 @@ func TestCommand_Install(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := c.Install(context.Background(), "user", "pass"); err != nil {
+	if err := c.Install(context.Background(), "user", "pass", ""); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestCommand_Install_ValuesFile(t *testing.T) {
+	expChartRepoCnt := 0
+	expChartRepo := []struct {
+		name string
+		url  string
+	}{
+		{name: airbyteRepoName, url: airbyteRepoURL},
+		{name: nginxRepoName, url: nginxRepoURL},
+	}
+
+	// userID is for telemetry tracking purposes
+	userID := uuid.New()
+
+	expChartCnt := 0
+	expChart := []struct {
+		chart   helmclient.ChartSpec
+		release release.Release
+	}{
+		{
+			chart: helmclient.ChartSpec{
+				ReleaseName:     airbyteChartRelease,
+				ChartName:       airbyteChartName,
+				Namespace:       airbyteNamespace,
+				CreateNamespace: true,
+				Wait:            true,
+				Timeout:         10 * time.Minute,
+				ValuesOptions:   values.Options{Values: []string{"global.env_vars.AIRBYTE_INSTALLATION_ID=" + userID.String()}},
+				ValuesYaml:      "global:\n  edition: \"test\"\n",
+			},
+			release: release.Release{
+				Chart:     &chart.Chart{Metadata: &chart.Metadata{Version: "1.2.3.4"}},
+				Name:      airbyteChartRelease,
+				Namespace: airbyteNamespace,
+				Version:   0,
+			},
+		},
+		{
+			chart: helmclient.ChartSpec{
+				ReleaseName:     nginxChartRelease,
+				ChartName:       nginxChartName,
+				Namespace:       nginxNamespace,
+				CreateNamespace: true,
+				Wait:            true,
+				Timeout:         10 * time.Minute,
+				ValuesOptions:   values.Options{Values: []string{fmt.Sprintf("controller.service.ports.http=%d", portTest)}},
+			},
+			release: release.Release{
+				Chart:     &chart.Chart{Metadata: &chart.Metadata{Version: "4.3.2.1"}},
+				Name:      nginxChartRelease,
+				Namespace: nginxNamespace,
+				Version:   0,
+			},
+		},
+	}
+	helm := mockHelmClient{
+		addOrUpdateChartRepo: func(entry repo.Entry) error {
+			if d := cmp.Diff(expChartRepo[expChartRepoCnt].name, entry.Name); d != "" {
+				t.Error("chart name mismatch", d)
+			}
+			if d := cmp.Diff(expChartRepo[expChartRepoCnt].url, entry.URL); d != "" {
+				t.Error("chart url mismatch", d)
+			}
+
+			expChartRepoCnt++
+
+			return nil
+		},
+
+		getChart: func(name string, _ *action.ChartPathOptions) (*chart.Chart, string, error) {
+			switch {
+			case name == airbyteChartName:
+				return &chart.Chart{Metadata: &chart.Metadata{Version: "test.airbyte.version"}}, "", nil
+			case name == nginxChartName:
+				return &chart.Chart{Metadata: &chart.Metadata{Version: "test.nginx.version"}}, "", nil
+			default:
+				t.Error("unsupported chart name", name)
+				return nil, "", errors.New("unexpected chart name")
+			}
+		},
+
+		installOrUpgradeChart: func(ctx context.Context, spec *helmclient.ChartSpec, opts *helmclient.GenericHelmOptions) (*release.Release, error) {
+			if d := cmp.Diff(&expChart[expChartCnt].chart, spec); d != "" {
+				t.Error("chart mismatch", d)
+			}
+
+			defer func() { expChartCnt++ }()
+
+			return &expChart[expChartCnt].release, nil
+		},
+	}
+
+	k8sClient := mockK8sClient{
+		serverVersionGet: func() (string, error) {
+			return "test", nil
+		},
+		secretCreateOrUpdate: func(ctx context.Context, namespace, name string, data map[string][]byte) error {
+			return nil
+		},
+		ingressExists: func(ctx context.Context, namespace string, ingress string) bool {
+			return false
+		},
+		ingressCreate: func(ctx context.Context, namespace string, ingress *networkingv1.Ingress) error {
+			return nil
+		},
+	}
+
+	attrs := map[string]string{}
+	tel := mockTelemetryClient{
+		attr: func(key, val string) { attrs[key] = val },
+		user: func() uuid.UUID { return userID },
+	}
+
+	httpClient := mockHTTP{do: func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200}, nil
+	}}
+
+	c, err := New(
+		k8s.TestProvider,
+		WithPortHTTP(portTest),
+		WithHelmClient(&helm),
+		WithK8sClient(&k8sClient),
+		WithTelemetryClient(&tel),
+		WithHTTPClient(&httpClient),
+		WithBrowserLauncher(func(url string) error {
+			return nil
+		}),
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.Install(context.Background(), "user", "pass", "testdata/values.yml"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCommand_Install_InvalidValuesFile(t *testing.T) {
+	c, err := New(
+		k8s.TestProvider,
+		WithPortHTTP(portTest),
+		WithHelmClient(&mockHelmClient{}),
+		WithK8sClient(&mockK8sClient{}),
+		WithTelemetryClient(&mockTelemetryClient{}),
+		WithHTTPClient(&mockHTTP{}),
+		WithBrowserLauncher(func(url string) error {
+			return nil
+		}),
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	valuesFile := "testdata/dne.yml"
+
+	err = c.Install(context.Background(), "user", "pass", valuesFile)
+	if err == nil {
+		t.Fatal("expecting an error, received none")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("could not read values file '%s'", valuesFile)) {
+		t.Error("unexpected error:", err)
+	}
+
 }
 
 // ---
@@ -237,7 +404,10 @@ func (m *mockK8sClient) ServiceGet(ctx context.Context, namespace, name string) 
 }
 
 func (m *mockK8sClient) ServerVersionGet() (string, error) {
-	return m.serverVersionGet()
+	if m.serverVersionGet != nil {
+		return m.serverVersionGet()
+	}
+	return "test", nil
 }
 
 func (m *mockK8sClient) EventsWatch(ctx context.Context, namespace string) (watch.Interface, error) {
@@ -277,7 +447,9 @@ func (m *mockTelemetryClient) Failure(ctx context.Context, eventType telemetry.E
 }
 
 func (m *mockTelemetryClient) Attr(key, val string) {
-	m.attr(key, val)
+	if m.attr != nil {
+		m.attr(key, val)
+	}
 }
 
 func (m *mockTelemetryClient) User() uuid.UUID {

--- a/internal/cmd/local/local/testdata/values.yml
+++ b/internal/cmd/local/local/testdata/values.yml
@@ -1,0 +1,2 @@
+global:
+  edition: "test"

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -22,6 +22,7 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	spinner := &pterm.DefaultSpinner
 
 	var (
+		flagChartValues  string
 		flagChartVersion string
 		flagUsername     string
 		flagPassword     string
@@ -138,6 +139,7 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	cmd.Flags().IntVar(&flagPort, "port", local.Port, "ingress http port")
 
 	cmd.Flags().StringVar(&flagChartVersion, "chart-version", "latest", "specify the specific Airbyte helm chart version to install")
+	cmd.Flags().StringVar(&flagChartVersion, "values", "", "specify the specific Airbyte helm chart version to install")
 
 	return cmd
 }

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -22,11 +22,11 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	spinner := &pterm.DefaultSpinner
 
 	var (
-		flagChartValues  string
-		flagChartVersion string
-		flagUsername     string
-		flagPassword     string
-		flagPort         int
+		flagChartValuesFile string
+		flagChartVersion    string
+		flagUsername        string
+		flagPassword        string
+		flagPort            int
 	)
 
 	cmd := &cobra.Command{
@@ -114,16 +114,14 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 					return fmt.Errorf("could not initialize local command: %w", err)
 				}
 
-				user := flagUsername
 				if env := os.Getenv(envBasicAuthUser); env != "" {
-					user = env
+					flagUsername = env
 				}
-				pass := flagPassword
 				if env := os.Getenv(envBasicAuthPass); env != "" {
-					pass = env
+					flagPassword = env
 				}
 
-				if err := lc.Install(cmd.Context(), user, pass); err != nil {
+				if err := lc.Install(cmd.Context(), flagUsername, flagPassword, flagChartValuesFile); err != nil {
 					spinner.Fail("Unable to install Airbyte locally")
 					return err
 				}
@@ -138,8 +136,8 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	cmd.Flags().StringVarP(&flagPassword, "password", "p", "password", "basic auth password, can also be specified via "+envBasicAuthPass)
 	cmd.Flags().IntVar(&flagPort, "port", local.Port, "ingress http port")
 
-	cmd.Flags().StringVar(&flagChartVersion, "chart-version", "latest", "specify the specific Airbyte helm chart version to install")
-	cmd.Flags().StringVar(&flagChartVersion, "values", "", "specify the specific Airbyte helm chart version to install")
+	cmd.Flags().StringVar(&flagChartVersion, "chart-version", "latest", "the Airbyte helm chart version to install")
+	cmd.Flags().StringVar(&flagChartValuesFile, "values", "", "the Airbyte helm chart values file to load")
 
 	return cmd
 }


### PR DESCRIPTION
Adds the ability to specify an (optional) values file to be used when running the helm install command.

```
abctl local install --values=path/to/values.yml
```

Verified that the underlying helm client we're using will merge the `values.yml` contents and the `value's options` values together:
```go
// GetValuesMap returns the merged mapped out values of a chart,
// using both ValuesYaml and ValuesOptions
func (spec *ChartSpec) GetValuesMap(p getter.Providers) (map[string]interface{}, error) {
	valuesYaml := map[string]interface{}{}

	err := yaml.Unmarshal([]byte(spec.ValuesYaml), &valuesYaml)
	if err != nil {
		return nil, errors.Wrap(err, "Failed to Parse ValuesYaml")
	}

	valuesOptions, err := spec.ValuesOptions.MergeValues(p)
	if err != nil {
		return nil, errors.Wrap(err, "Failed to Parse ValuesOptions")
	}

	return values.MergeMaps(valuesYaml, valuesOptions), nil
}
```