### PR TITLE
feat: support docker login

### DIFF
--- a/internal/cmd/local/docker/secret.go
+++ b/internal/cmd/local/docker/secret.go
@@ -1,0 +1,49 @@
+package docker
+
+import (
+	"encoding/base64"
+	"encoding/json"
+)
+
+// Secret generates a docker registry secret that can be stored as a k8s secret
+// and used to pull images from docker hub (or any other registry) in an
+// authenticated manner.
+// The format if the []byte in string form will be
+//
+//	{
+//	  "auths": {
+//	    "[SERVER]": {
+//	      "username": "[USER]",
+//	      "password": "[PASS]",
+//	      "email": "[EMAIL]",
+//	      "auth"; "[base64 encoding of 'user:pass']"
+//	    }
+//	  }
+//	}
+func Secret(server, user, pass, email string) ([]byte, error) {
+	// map of the server to the credentials
+	servers := map[string]credential{
+		server: newCredential(user, pass, email),
+	}
+	auths := map[string]map[string]credential{
+		"auths": servers,
+	}
+
+	return json.Marshal(auths)
+}
+
+type credential struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Email    string `json:"email"`
+	Auth     string `json:"auth"`
+}
+
+func newCredential(user, pass, email string) credential {
+	return credential{
+		Username: user,
+		Password: pass,
+		Email:    email,
+		Auth:     base64.StdEncoding.EncodeToString([]byte(user + ":" + pass)),
+	}
+}

--- a/internal/cmd/local/docker/secret_test.go
+++ b/internal/cmd/local/docker/secret_test.go
@@ -1,0 +1,17 @@
+package docker
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+func Test_Secret(t *testing.T) {
+	exp := `{"auths":{"my-registry.example:5000":{"username":"tiger","password":"pass1234","email":"tiger@acme.example","auth":"dGlnZXI6cGFzczEyMzQ="}}}`
+	act, err := Secret("my-registry.example:5000", "tiger", "pass1234", "tiger@acme.example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d := cmp.Diff(exp, string(act)); d != "" {
+		t.Errorf("Secret mismatch (-want +got):\n%s", d)
+	}
+}

--- a/internal/cmd/local/k8s/client.go
+++ b/internal/cmd/local/k8s/client.go
@@ -50,7 +50,7 @@ type Client interface {
 	PersistentVolumeClaimDelete(ctx context.Context, namespace, name, volumeName string) error
 
 	// SecretCreateOrUpdate will update or create the secret name with the payload of data in the specified namespace
-	SecretCreateOrUpdate(ctx context.Context, namespace, name string, data map[string][]byte) error
+	SecretCreateOrUpdate(ctx context.Context, secretType corev1.SecretType, namespace, name string, data map[string][]byte) error
 
 	// ServiceGet returns a the service for the given namespace and name
 	ServiceGet(ctx context.Context, namespace, name string) (*corev1.Service, error)
@@ -175,7 +175,7 @@ func (d *DefaultK8sClient) PersistentVolumeClaimDelete(ctx context.Context, name
 	return d.ClientSet.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 }
 
-func (d *DefaultK8sClient) SecretCreateOrUpdate(ctx context.Context, namespace, name string, data map[string][]byte) error {
+func (d *DefaultK8sClient) SecretCreateOrUpdate(ctx context.Context, secretType corev1.SecretType, namespace, name string, data map[string][]byte) error {
 	secret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
@@ -183,6 +183,7 @@ func (d *DefaultK8sClient) SecretCreateOrUpdate(ctx context.Context, namespace, 
 			Name:      name,
 		},
 		Data: data,
+		Type: secretType,
 	}
 	_, err := d.ClientSet.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err == nil {

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -334,7 +334,7 @@ func (c *Command) Install(ctx context.Context, opts InstallOpts) error {
 			return fmt.Errorf("could not create '%s' secret: %w", dockerAuthSecretName, err)
 		}
 		pterm.Debug.Println(fmt.Sprintf("Created '%s' secret", dockerAuthSecretName))
-		airbyteValues = append(airbyteValues, fmt.Sprintf("global.imagePullSecrets=%s", dockerAuthSecretName))
+		airbyteValues = append(airbyteValues, fmt.Sprintf("global.imagePullSecrets[0].name=%s", dockerAuthSecretName))
 	}
 
 	if err := c.handleChart(ctx, chartRequest{

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -535,7 +535,7 @@ func (c *Command) handleDockerSecret(ctx context.Context, server, user, pass, em
 		pterm.Error.Println("Could not create Docker-auth secret")
 		return fmt.Errorf("unable to create docker-auth secret: %w", err)
 	}
-	pterm.Success.Println("Docker-auth secret created")
+	pterm.Success.Println("Docker-Auth secret created")
 	return nil
 }
 

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -746,7 +746,7 @@ func defaultHelm(kubecfg, kubectx string) (HelmClient, error) {
 	return helm, nil
 }
 
-// k8sClientConfig returns a k8s client config using the ~/.kubc/config file and the k8sContext context.
+// k8sClientConfig returns a k8s client config using the ~/.kube/config file and the k8sContext context.
 func k8sClientConfig(kubecfg, kubectx string) (clientcmd.ClientConfig, error) {
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubecfg},

--- a/internal/cmd/local/local/cmd_test.go
+++ b/internal/cmd/local/local/cmd_test.go
@@ -121,7 +121,7 @@ func TestCommand_Install(t *testing.T) {
 		serverVersionGet: func() (string, error) {
 			return "test", nil
 		},
-		secretCreateOrUpdate: func(ctx context.Context, namespace, name string, data map[string][]byte) error {
+		secretCreateOrUpdate: func(ctx context.Context, secretType coreV1.SecretType, namespace, name string, data map[string][]byte) error {
 			return nil
 		},
 		ingressExists: func(ctx context.Context, namespace string, ingress string) bool {
@@ -158,7 +158,7 @@ func TestCommand_Install(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := c.Install(context.Background(), InstallOpts{User: "user", Pass: "pass"}); err != nil {
+	if err := c.Install(context.Background(), InstallOpts{BasicAuthUser: "user", BasicAuthPass: "pass"}); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -258,7 +258,7 @@ func TestCommand_Install_ValuesFile(t *testing.T) {
 		serverVersionGet: func() (string, error) {
 			return "test", nil
 		},
-		secretCreateOrUpdate: func(ctx context.Context, namespace, name string, data map[string][]byte) error {
+		secretCreateOrUpdate: func(ctx context.Context, secretType coreV1.SecretType, namespace, name string, data map[string][]byte) error {
 			return nil
 		},
 		ingressExists: func(ctx context.Context, namespace string, ingress string) bool {
@@ -295,7 +295,7 @@ func TestCommand_Install_ValuesFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := c.Install(context.Background(), InstallOpts{User: "user", Pass: "pass", ValuesFile: "testdata/values.yml"}); err != nil {
+	if err := c.Install(context.Background(), InstallOpts{BasicAuthUser: "user", BasicAuthPass: "pass", ValuesFile: "testdata/values.yml"}); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -319,7 +319,7 @@ func TestCommand_Install_InvalidValuesFile(t *testing.T) {
 
 	valuesFile := "testdata/dne.yml"
 
-	err = c.Install(context.Background(), InstallOpts{User: "user", Pass: "pass", ValuesFile: valuesFile})
+	err = c.Install(context.Background(), InstallOpts{BasicAuthUser: "user", BasicAuthPass: "pass", ValuesFile: valuesFile})
 	if err == nil {
 		t.Fatal("expecting an error, received none")
 	}
@@ -377,7 +377,7 @@ type mockK8sClient struct {
 	persistentVolumeClaimCreate func(ctx context.Context, namespace, name, volumeName string) error
 	persistentVolumeClaimExists func(ctx context.Context, namespace, name, volumeName string) bool
 	persistentVolumeClaimDelete func(ctx context.Context, namespace, name, volumeName string) error
-	secretCreateOrUpdate        func(ctx context.Context, namespace, name string, data map[string][]byte) error
+	secretCreateOrUpdate        func(ctx context.Context, secretType coreV1.SecretType, namespace, name string, data map[string][]byte) error
 	serviceGet                  func(ctx context.Context, namespace, name string) (*coreV1.Service, error)
 	serverVersionGet            func() (string, error)
 	eventsWatch                 func(ctx context.Context, namespace string) (watch.Interface, error)
@@ -464,9 +464,9 @@ func (m *mockK8sClient) PersistentVolumeClaimDelete(ctx context.Context, namespa
 	return nil
 }
 
-func (m *mockK8sClient) SecretCreateOrUpdate(ctx context.Context, namespace, name string, data map[string][]byte) error {
+func (m *mockK8sClient) SecretCreateOrUpdate(ctx context.Context, secretType coreV1.SecretType, namespace, name string, data map[string][]byte) error {
 	if m.secretCreateOrUpdate != nil {
-		return m.secretCreateOrUpdate(ctx, namespace, name, data)
+		return m.secretCreateOrUpdate(ctx, secretType, namespace, name, data)
 	}
 
 	return nil

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -191,7 +191,6 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	cmd.Flags().StringVar(&flagDockerPass, "docker-password", "", "docker password, can also be specified via "+envDockerPass)
 	cmd.Flags().StringVar(&flagDockerEmail, "docker-email", "", "docker email, can also be specified via "+envDockerEmail)
 
-	cmd.MarkFlagsMutuallyExclusive("docker-file", "docker-username")
 	cmd.MarkFlagsRequiredTogether("docker-username", "docker-password", "docker-email")
 
 	return cmd

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -39,7 +39,6 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 		flagMigrate         bool
 		flagPort            int
 
-		flagDockerFile   string
 		flagDockerServer string
 		flagDockerUser   string
 		flagDockerPass   string
@@ -138,7 +137,6 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 					Migrate:          flagMigrate,
 					Docker:           dockerClient,
 
-					DockerFile:   flagDockerFile,
 					DockerServer: flagDockerServer,
 					DockerUser:   flagDockerUser,
 					DockerPass:   flagDockerPass,
@@ -148,12 +146,14 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 				if opts.HelmChartVersion == "latest" {
 					opts.HelmChartVersion = ""
 				}
+
 				if env := os.Getenv(envBasicAuthUser); env != "" {
 					opts.BasicAuthUser = env
 				}
 				if env := os.Getenv(envBasicAuthPass); env != "" {
 					opts.BasicAuthPass = env
 				}
+
 				if env := os.Getenv(envDockerServer); env != "" {
 					opts.DockerServer = env
 				}
@@ -186,7 +186,6 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	cmd.Flags().StringVar(&flagChartValuesFile, "values", "", "the Airbyte helm chart values file to load")
 	cmd.Flags().BoolVar(&flagMigrate, "migrate", false, "migrate data from docker compose installation")
 
-	cmd.Flags().StringVar(&flagDockerFile, "docker-file", "", "docker login credentials file")
 	cmd.Flags().StringVar(&flagDockerServer, "docker-server", "https://index.docker.io/v1/", "docker registry, can also be specified via "+envDockerServer)
 	cmd.Flags().StringVar(&flagDockerUser, "docker-username", "", "docker username, can also be specified via "+envDockerEmail)
 	cmd.Flags().StringVar(&flagDockerPass, "docker-password", "", "docker password, can also be specified via "+envDockerPass)


### PR DESCRIPTION
- add the _optional_ ability to provide docker login credentials which will be used to pull images from inside the `abctl` managed cluster
    - `docker-username`
    - `docker-password`
    - `docker-email`
    - `docker-server` 