### PR TITLE
fix: set proper ownership and permissions of the persisted volume directories

### DIFF
--- a/internal/cmd/local/k8s/cluster.go
+++ b/internal/cmd/local/k8s/cluster.go
@@ -34,6 +34,9 @@ type kindCluster struct {
 const k8sVersion = "v1.29.1"
 
 func (k *kindCluster) Create(port int) error {
+	// Create the data directory before the cluster does to ensure that it's owned by the correct user.
+	// If the cluster creates it and docker is running as root, it's possible that root will own this directory
+	// which will cause minio and postgres to break.
 	pterm.Debug.Println(fmt.Sprintf("Creating data directory '%s'", paths.Data))
 	if err := os.MkdirAll(paths.Data, 0755); err != nil {
 		pterm.Error.Println(fmt.Sprintf("Error creating data directory '%s'", paths.Data))

--- a/internal/cmd/local/k8s/cluster.go
+++ b/internal/cmd/local/k8s/cluster.go
@@ -3,6 +3,8 @@ package k8s
 import (
 	"fmt"
 	"github.com/airbytehq/abctl/internal/cmd/local/paths"
+	"github.com/pterm/pterm"
+	"os"
 	"sigs.k8s.io/kind/pkg/cluster"
 	"time"
 )
@@ -32,6 +34,12 @@ type kindCluster struct {
 const k8sVersion = "v1.29.1"
 
 func (k *kindCluster) Create(port int) error {
+	pterm.Debug.Println(fmt.Sprintf("Creating data directory '%s'", paths.Data))
+	if err := os.MkdirAll(paths.Data, 0755); err != nil {
+		pterm.Error.Println(fmt.Sprintf("Error creating data directory '%s'", paths.Data))
+		return fmt.Errorf("unable to create directory '%s': %w", paths.Data, err)
+	}
+
 	// see https://kind.sigs.k8s.io/docs/user/ingress/#create-cluster
 	rawCfg := fmt.Sprintf(`kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4


### PR DESCRIPTION
- fix airbytehq/airbyte-internal-issues#8569
- create the persisted volume directories before k8s does
    - this is necessary as the k8s created directories will be owned by the user that is running the docker daemon, not the user that is running `abctl`
- set the permissions on the persisted volume directories to `0777`
    - this is necessary due to the postgres image using a custom postgres/postgres user with uid/gid of `70:70` which may not exist on the host machine and therefore the directory needs globally writable permissions