### PR TITLE
feat: increase default cpu/mem limits

### DIFF
--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -367,6 +367,8 @@ func (c *Command) Install(ctx context.Context, opts InstallOpts) error {
 
 	airbyteValues := []string{
 		fmt.Sprintf("global.env_vars.AIRBYTE_INSTALLATION_ID=%s", telUser),
+		fmt.Sprintf("global.jobs.resources.limits.cpu=3"),
+		fmt.Sprintf("global.jobs.resources.limits.memory=4Gi"),
 	}
 
 	if opts.dockerAuth() {

--- a/internal/cmd/local/local/cmd_test.go
+++ b/internal/cmd/local/local/cmd_test.go
@@ -53,6 +53,8 @@ func TestCommand_Install(t *testing.T) {
 				Timeout:         10 * time.Minute,
 				ValuesOptions: values.Options{Values: []string{
 					"global.env_vars.AIRBYTE_INSTALLATION_ID=" + userID.String(),
+					"global.jobs.resources.limits.cpu=3",
+					"global.jobs.resources.limits.memory=4Gi",
 				}},
 			},
 			release: release.Release{
@@ -189,8 +191,12 @@ func TestCommand_Install_ValuesFile(t *testing.T) {
 				CreateNamespace: true,
 				Wait:            true,
 				Timeout:         10 * time.Minute,
-				ValuesOptions:   values.Options{Values: []string{"global.env_vars.AIRBYTE_INSTALLATION_ID=" + userID.String()}},
-				ValuesYaml:      "global:\n  edition: \"test\"\n",
+				ValuesOptions: values.Options{Values: []string{
+					"global.env_vars.AIRBYTE_INSTALLATION_ID=" + userID.String(),
+					"global.jobs.resources.limits.cpu=3",
+					"global.jobs.resources.limits.memory=4Gi",
+				}},
+				ValuesYaml: "global:\n  edition: \"test\"\n",
 			},
 			release: release.Release{
 				Chart:     &chart.Chart{Metadata: &chart.Metadata{Version: "1.2.3.4"}},


### PR DESCRIPTION
- fix airbytehq/airbyte-internal-issues#8352
- set the default cpu limit to 3 cores
- set the default mem limit to 4 gigs