### PR TITLE
fix: nil `analytics_id`/`anonymous_user_id` causing panics

### DIFF
--- a/internal/telemetry/config.go
+++ b/internal/telemetry/config.go
@@ -137,18 +137,24 @@ func loadConfigFromFile(path string) (Config, error) {
 		return Config{}, fmt.Errorf("could not unmarshal yaml: %w", err)
 	}
 	if v, ok := c.Other[fieldUserID]; ok {
-		if parsed, err := ulid.Parse(v.(string)); err != nil {
-			return Config{}, fmt.Errorf("could not parse ulid (%s): %w", v, err)
-		} else {
-			c.UserID = ULID(parsed)
+		// the field can exist with a nil value, verify the value is a string before using it as a string
+		if s, ok := v.(string); ok {
+			if parsed, err := ulid.Parse(s); err != nil {
+				return Config{}, fmt.Errorf("could not parse ulid (%s): %w", v, err)
+			} else {
+				c.UserID = ULID(parsed)
+			}
 		}
 	}
 
 	if v, ok := c.Other[fieldAnalyticsID]; ok {
-		if parsed, err := uuid.Parse(v.(string)); err != nil {
-			return Config{}, fmt.Errorf("could not parse uuid (%s): %w", v, err)
-		} else {
-			c.AnalyticsID = UUID(parsed)
+		// the field can exist with a nil value, verify the value is a string before using it as a string
+		if s, ok := v.(string); ok {
+			if parsed, err := uuid.Parse(s); err != nil {
+				return Config{}, fmt.Errorf("could not parse uuid (%s): %w", v, err)
+			} else {
+				c.AnalyticsID = UUID(parsed)
+			}
 		}
 	}
 

--- a/internal/telemetry/config_test.go
+++ b/internal/telemetry/config_test.go
@@ -198,6 +198,65 @@ total: 300`,
 	})
 }
 
+func TestLoadConfigWithNilFields(t *testing.T) {
+	t.Run("nil anonymous_user_id", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "analytics-")
+		if err != nil {
+			t.Fatal("could not create temp file", err)
+		}
+		defer f.Close()
+
+		cfgData := fmt.Sprintf(`# comments
+%s: %s
+%s:
+`,
+			fieldAnalyticsID, uuidID.String(), fieldUserID)
+
+		if _, err := f.WriteString(cfgData); err != nil {
+			t.Fatal("could not write to temp file", err)
+		}
+
+		cfg, err := loadConfigFromFile(f.Name())
+		if d := cmp.Diff(nil, err); d != "" {
+			t.Error("failed to load file", d)
+		}
+
+		if d := cmp.Diff(uuidID.String(), cfg.AnalyticsID.String()); d != "" {
+			t.Error("analyticsID is incorrect", d)
+		}
+
+		if d := cmp.Diff(true, cfg.UserID.IsZero()); d != "" {
+			t.Error("userID is incorrect", d)
+		}
+	})
+
+	t.Run("nil analytics_id", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "analytics-")
+		if err != nil {
+			t.Fatal("could not create temp file", err)
+		}
+		defer f.Close()
+
+		cfgData := fmt.Sprintf(`# comments
+%s:
+`,
+			fieldAnalyticsID)
+
+		if _, err := f.WriteString(cfgData); err != nil {
+			t.Fatal("could not write to temp file", err)
+		}
+
+		cfg, err := loadConfigFromFile(f.Name())
+		if d := cmp.Diff(nil, err); d != "" {
+			t.Error("failed to load file", d)
+		}
+
+		if d := cmp.Diff(true, cfg.AnalyticsID.IsZero()); d != "" {
+			t.Error("id is incorrect", d)
+		}
+	})
+}
+
 func TestWriteConfig(t *testing.T) {
 	t.Run("ulid", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "nested", "deeply", ConfigFile)


### PR DESCRIPTION
- fix airbytehq/airbyte#40745
- verify the analytics configuration keys `analytics_id` and `anonymous_user_id` are strings
    - Prior to this fix, if the keys `analytics_id` or `anonymous_user_id` existed in the `analytics.yml` file without a value (`analytics_id:`), the code would incorrectly assume that a valid key also meant a valid value and would panic if this turned out to not be the case.
- add two tests to also verify the panic existing behavior and fixed new behavior