### PR TITLE
fix: panic related to port listener

### DIFF
--- a/internal/cmd/local/check.go
+++ b/internal/cmd/local/check.go
@@ -96,7 +96,10 @@ func portAvailable(ctx context.Context, port int) error {
 			port, res.StatusCode, body,
 		))
 
-		pterm.Error.Println(fmt.Sprintf("Unable to determine if port '%d' is available", port))
+		pterm.Error.Println(fmt.Sprintf(
+			"Unable to determine if port '%d' is available, consider specifying a different port",
+			port,
+		))
 		return fmt.Errorf("unable to determine if port '%d' is available: %w", port, err)
 	}
 	// if we're able to bind to the port (and then release it), it should be available


### PR DESCRIPTION
- fix an issue where the listener would fail to start and the error returned could be ignored
    - this would happen if 
        - the initial listen action failed (b/c the port was available)
        - a request to what was listening on the port returned a http response
        - the http response was anything other than a `401`
- replace `net.Listener` to use context aware `net.ListenConfig` instead