### PR TITLE
feat: add debug logging for kind commands

### DIFF
--- a/internal/cmd/local/k8s/cluster.go
+++ b/internal/cmd/local/k8s/cluster.go
@@ -68,7 +68,7 @@ nodes:
 		port)
 
 	opts := []cluster.CreateOption{
-		cluster.CreateWithWaitForReady(120 * time.Second),
+		cluster.CreateWithWaitForReady(5 * time.Minute),
 		cluster.CreateWithKubeconfigPath(k.kubeconfig),
 		cluster.CreateWithNodeImage("kindest/node:" + k8sVersion),
 		cluster.CreateWithRawConfig([]byte(rawCfg)),


### PR DESCRIPTION
- add support for outputting kind log messages
    - by default these message are noops, this PR creates a implementation that converts them to the pterm debug logger 
- increase wait-time for kind cluster; 2m -> 5m