### PR TITLE
feat: add debug logs for helm

### DIFF
--- a/internal/cmd/local/helm/helm.go
+++ b/internal/cmd/local/helm/helm.go
@@ -34,8 +34,14 @@ func New(kubecfg, kubectx, namespace string) (Client, error) {
 		return nil, fmt.Errorf("%w: could not create rest config: %w", localerr.ErrKubernetes, err)
 	}
 
+	logger := &helmLogger{}
 	helm, err := helmclient.NewClientFromRestConf(&helmclient.RestConfClientOptions{
-		Options:    &helmclient.Options{Namespace: namespace, Output: &helmLogger{}, DebugLog: func(format string, v ...interface{}) {}},
+		Options: &helmclient.Options{
+			Namespace: namespace,
+			Output:    logger,
+			DebugLog:  logger.Debug,
+			Debug:     true,
+		},
 		RestConfig: restCfg,
 	})
 	if err != nil {
@@ -52,4 +58,8 @@ type helmLogger struct {
 func (d *helmLogger) Write(p []byte) (int, error) {
 	pterm.Debug.Println(fmt.Sprintf("helm: %s", string(p)))
 	return len(p), nil
+}
+
+func (d *helmLogger) Debug(format string, v ...interface{}) {
+	pterm.Debug.Println(fmt.Sprintf("helm - DEBUG: "+format, v...))
 }

--- a/internal/cmd/local/helm/helm.go
+++ b/internal/cmd/local/helm/helm.go
@@ -50,6 +50,6 @@ type helmLogger struct {
 }
 
 func (d *helmLogger) Write(p []byte) (int, error) {
-	pterm.Debug.Println(fmt.Sprintf("helm: %s", string(p))))
+	pterm.Debug.Println(fmt.Sprintf("helm: %s", string(p)))
 	return len(p), nil
 }

--- a/internal/cmd/local/helm/helm.go
+++ b/internal/cmd/local/helm/helm.go
@@ -1,0 +1,55 @@
+package helm
+
+import (
+	"context"
+	"fmt"
+	"github.com/airbytehq/abctl/internal/cmd/local/localerr"
+	helmclient "github.com/mittwald/go-helm-client"
+	"github.com/pterm/pterm"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/repo"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Client primarily for testing purposes
+type Client interface {
+	AddOrUpdateChartRepo(entry repo.Entry) error
+	GetChart(string, *action.ChartPathOptions) (*chart.Chart, string, error)
+	GetRelease(name string) (*release.Release, error)
+	InstallOrUpgradeChart(ctx context.Context, spec *helmclient.ChartSpec, opts *helmclient.GenericHelmOptions) (*release.Release, error)
+	UninstallReleaseByName(string) error
+}
+
+// New returns the default helm client
+func New(kubecfg, kubectx, namespace string) (Client, error) {
+	k8sCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubecfg},
+		&clientcmd.ConfigOverrides{CurrentContext: kubectx},
+	)
+
+	restCfg, err := k8sCfg.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("%w: could not create rest config: %w", localerr.ErrKubernetes, err)
+	}
+
+	helm, err := helmclient.NewClientFromRestConf(&helmclient.RestConfClientOptions{
+		Options:    &helmclient.Options{Namespace: namespace, Output: &helmLogger{}, DebugLog: func(format string, v ...interface{}) {}},
+		RestConfig: restCfg,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to create helm client: %w", err)
+	}
+
+	return helm, nil
+}
+
+// helmLogger is used by the Client to convert all helm output into debug logs.
+type helmLogger struct {
+}
+
+func (d *helmLogger) Write(p []byte) (int, error) {
+	pterm.Debug.Println(fmt.Sprintf("helm: %s", string(p))))
+	return len(p), nil
+}

--- a/internal/cmd/local/helm/helm.go
+++ b/internal/cmd/local/helm/helm.go
@@ -17,10 +17,10 @@ import (
 // Client primarily for testing purposes
 type Client interface {
 	AddOrUpdateChartRepo(entry repo.Entry) error
-	GetChart(string, *action.ChartPathOptions) (*chart.Chart, string, error)
+	GetChart(name string, options *action.ChartPathOptions) (*chart.Chart, string, error)
 	GetRelease(name string) (*release.Release, error)
 	InstallOrUpgradeChart(ctx context.Context, spec *helmclient.ChartSpec, opts *helmclient.GenericHelmOptions) (*release.Release, error)
-	UninstallReleaseByName(string) error
+	UninstallReleaseByName(name string) error
 }
 
 // New returns the default helm client

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -755,41 +755,10 @@ func defaultK8s(kubecfg, kubectx string) (k8s.Client, error) {
 	return &k8s.DefaultK8sClient{ClientSet: k8sClient}, nil
 }
 
-// defaultHelm returns the default helm client
-func defaultHelm(kubecfg, kubectx string) (helm.Client, error) {
-	k8sCfg, err := k8sClientConfig(kubecfg, kubectx)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %w", localerr.ErrKubernetes, err)
-	}
-
-	restCfg, err := k8sCfg.ClientConfig()
-	if err != nil {
-		return nil, fmt.Errorf("%w: could not create rest config: %w", localerr.ErrKubernetes, err)
-	}
-
-	helm, err := helmclient.NewClientFromRestConf(&helmclient.RestConfClientOptions{
-		Options:    &helmclient.Options{Namespace: airbyteNamespace, Output: &noopWriter{}, DebugLog: func(format string, v ...interface{}) {}},
-		RestConfig: restCfg,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("unable to create helm client: %w", err)
-	}
-
-	return helm, nil
-}
-
 // k8sClientConfig returns a k8s client config using the ~/.kube/config file and the k8sContext context.
 func k8sClientConfig(kubecfg, kubectx string) (clientcmd.ClientConfig, error) {
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubecfg},
 		&clientcmd.ConfigOverrides{CurrentContext: kubectx},
 	), nil
-}
-
-// noopWriter is used by the helm client to suppress its verbose output
-type noopWriter struct {
-}
-
-func (w *noopWriter) Write(p []byte) (int, error) {
-	return len(p), nil
 }

--- a/internal/cmd/local/local/cmd_test.go
+++ b/internal/cmd/local/local/cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/airbytehq/abctl/internal/cmd/local/helm"
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/google/go-cmp/cmp"
@@ -338,7 +339,7 @@ func TestCommand_Install_InvalidValuesFile(t *testing.T) {
 // ---
 // only mocks below here
 // ---
-var _ HelmClient = (*mockHelmClient)(nil)
+var _ helm.Client = (*mockHelmClient)(nil)
 
 type mockHelmClient struct {
 	addOrUpdateChartRepo   func(entry repo.Entry) error


### PR DESCRIPTION
- replace the `noopWriter` with a `helmLogger`
    - helm generates _a lot_ of logs, which is why it was originally noop'd but there may be some useful information in those logs, which is why they are not output as debug logs 