### PR TITLE
feat: attempt to fix invalid ~/.airbyte permissions

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -14,6 +14,10 @@ import (
 
 // Help messages to display for specific error situations.
 const (
+	// helpAirbyteDir is display if ErrAirbyteDir is ever returned
+	helpAirbyteDir = `The ~/.airbyte directory is inaccessible.
+You may need to remove this directory before trying your command again.`
+
 	// helpDocker is displayed if ErrDocker is ever returned
 	helpDocker = `An error occurred while communicating with the Docker daemon.
 Ensure that Docker is running and is accessible.  You may need to upgrade to a newer version of Docker.
@@ -41,16 +45,20 @@ func Execute(ctx context.Context, cmd *cobra.Command) {
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		pterm.Error.Println(err)
 
-		if errors.Is(err, localerr.ErrDocker) {
+		switch {
+		case errors.Is(err, localerr.ErrAirbyteDir):
+			pterm.Println()
+			pterm.Info.Println(helpAirbyteDir)
+		case errors.Is(err, localerr.ErrDocker):
 			pterm.Println()
 			pterm.Info.Println(helpDocker)
-		} else if errors.Is(err, localerr.ErrKubernetes) {
+		case errors.Is(err, localerr.ErrKubernetes):
 			pterm.Println()
 			pterm.Info.Println(helpKubernetes)
-		} else if errors.Is(err, localerr.ErrIngress) {
+		case errors.Is(err, localerr.ErrIngress):
 			pterm.Println()
 			pterm.Info.Println(helpIngress)
-		} else if errors.Is(err, localerr.ErrPort) {
+		case errors.Is(err, localerr.ErrPort):
 			pterm.Println()
 			pterm.Info.Printfln(helpPort)
 		}

--- a/internal/cmd/local/local_test.go
+++ b/internal/cmd/local/local_test.go
@@ -1,0 +1,90 @@
+package local
+
+import (
+	"github.com/airbytehq/abctl/internal/cmd/local/paths"
+	"github.com/google/go-cmp/cmp"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckAirbyteDir(t *testing.T) {
+	origDir := paths.Airbyte
+	t.Cleanup(func() {
+		paths.Airbyte = origDir
+	})
+
+	t.Run("no directory", func(t *testing.T) {
+		paths.Airbyte = filepath.Join(t.TempDir(), "does-not-exist")
+		if err := checkAirbyteDir(); err != nil {
+			t.Error("unexpected error", err)
+		}
+	})
+
+	t.Run("directory with correct permissions", func(t *testing.T) {
+		paths.Airbyte = filepath.Join(t.TempDir(), "correct-perms")
+		if err := os.MkdirAll(paths.Airbyte, 0744); err != nil {
+			t.Fatal("unable to create test directory", err)
+		}
+		if err := os.Chmod(paths.Airbyte, 0744); err != nil {
+			t.Fatal("unable to change permissions", err)
+		}
+		if err := checkAirbyteDir(); err != nil {
+			t.Error("unexpected error", err)
+		}
+
+		// permissions should be unchanged
+		perms, err := os.Stat(paths.Airbyte)
+		if err != nil {
+			t.Fatal("unable to check permissions", err)
+		}
+		if d := cmp.Diff(0744, int(perms.Mode().Perm())); d != "" {
+			t.Errorf("permissions mismatch (-want +got):\n%s", d)
+		}
+	})
+
+	t.Run("directory with higher permissions", func(t *testing.T) {
+		paths.Airbyte = filepath.Join(t.TempDir(), "correct-perms")
+		if err := os.MkdirAll(paths.Airbyte, 0777); err != nil {
+			t.Fatal("unable to create test directory", err)
+		}
+		if err := os.Chmod(paths.Airbyte, 0777); err != nil {
+			t.Fatal("unable to change permissions", err)
+		}
+		if err := checkAirbyteDir(); err != nil {
+			t.Error("unexpected error", err)
+		}
+
+		// permissions should be unchanged
+		perms, err := os.Stat(paths.Airbyte)
+		if err != nil {
+			t.Fatal("unable to check permissions", err)
+		}
+		if d := cmp.Diff(0777, int(perms.Mode().Perm())); d != "" {
+			t.Errorf("permissions mismatch (-want +got):\n%s", d)
+		}
+	})
+
+	t.Run("directory with incorrect permissions", func(t *testing.T) {
+		paths.Airbyte = filepath.Join(t.TempDir(), "incorrect-perms")
+		if err := os.MkdirAll(paths.Airbyte, 0200); err != nil {
+			t.Fatal("unable to create test directory", err)
+		}
+		if err := os.Chmod(paths.Airbyte, 0200); err != nil {
+			t.Fatal("unable to change permissions", err)
+		}
+		// although the permissions are incorrect, checkAirbyteDir should fix them
+		if err := checkAirbyteDir(); err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		// permissions should be changed
+		perms, err := os.Stat(paths.Airbyte)
+		if err != nil {
+			t.Fatal("unable to check permissions", err)
+		}
+		if d := cmp.Diff(0744, int(perms.Mode().Perm())); d != "" {
+			t.Errorf("permissions mismatch (-want +got):\n%s", d)
+		}
+	})
+}

--- a/internal/cmd/local/localerr/localerr.go
+++ b/internal/cmd/local/localerr/localerr.go
@@ -3,6 +3,9 @@ package localerr
 import "errors"
 
 var (
+	// ErrAirbyteDir is returned anytime an there is an issue in accessing the paths.Airbyte directory.
+	ErrAirbyteDir = errors.New("airbyte directory is inaccessible")
+
 	// ErrDocker is returned anytime an error occurs when attempting to communicate with docker.
 	ErrDocker = errors.New("error communicating with docker")
 


### PR DESCRIPTION
- check if the `~/.airbyte` directory has correct permissions
    - due to a bug in an earlier version of `abctl` the `~/.airbyte` directory may have been created with incorrect permissions
        - this bug was fixed in `v0.9.1`
- if it has incorrect permissions, attempt to fix them, if they cannot be fixed display a helpful error message to the user asking them to fix it
 