### PR TITLE
feat: add --no-browser flag

### DIFF
--- a/internal/cmd/local/k8s/provider.go
+++ b/internal/cmd/local/k8s/provider.go
@@ -74,7 +74,7 @@ func (k *kindLogger) Errorf(format string, args ...interface{}) {
 	k.pterm.Println(fmt.Sprintf("kind - ERROR: "+format, args...))
 }
 
-func (k *kindLogger) V(level log.Level) log.InfoLogger {
+func (k *kindLogger) V(_ log.Level) log.InfoLogger {
 	return k
 }
 

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -459,8 +459,8 @@ func (c *Command) Install(ctx context.Context, opts InstallOpts) error {
 			"Launching web-browser disabled. Airbyte should be accessible at\n  %s",
 			url,
 		))
-	} else if err := c.launch(url); err != nil {
-		return err
+	} else {
+		c.launch(url)
 	}
 
 	return nil
@@ -796,19 +796,20 @@ func (c *Command) verifyIngress(ctx context.Context, url string) error {
 	return nil
 }
 
-func (c *Command) launch(url string) error {
+func (c *Command) launch(url string) {
 	c.spinner.UpdateText(fmt.Sprintf("Attempting to launch web-browser for %s", url))
 
 	if err := c.launcher(url); err != nil {
-		pterm.Warning.Printfln("Failed to launch web-browser.\n"+
-			"Please launch your web-browser to access %s", url)
-		pterm.Debug.Printfln("failed to launch web-browser: %s", err.Error())
+		pterm.Warning.Println(fmt.Sprintf(
+			"Failed to launch web-browser.\nPlease launch your web-browser to access %s",
+			url,
+		))
+		pterm.Debug.Println(fmt.Sprintf("failed to launch web-browser: %s", err.Error()))
 		// don't consider a failed web-browser to be a failed installation
+		return
 	}
 
 	pterm.Success.Println(fmt.Sprintf("Launched web-browser successfully for %s", url))
-
-	return nil
 }
 
 // defaultK8s returns the default k8s client

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -190,7 +190,7 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	cmd.Flags().StringVar(&flagDockerPass, "docker-password", "", "docker password, can also be specified via "+envDockerPass)
 	cmd.Flags().StringVar(&flagDockerEmail, "docker-email", "", "docker email, can also be specified via "+envDockerEmail)
 
-	cmd.Flags().BoolVar(&flagNoBrowser, "no-browser", false, "disabling attempting to launch the web-browser")
+	cmd.Flags().BoolVar(&flagNoBrowser, "no-browser", false, "disable launching the web-browser post install")
 
 	cmd.MarkFlagsRequiredTogether("docker-username", "docker-password", "docker-email")
 

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -45,6 +45,8 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 		flagDockerUser   string
 		flagDockerPass   string
 		flagDockerEmail  string
+
+		flagNoBrowser bool
 	)
 
 	cmd := &cobra.Command{
@@ -145,6 +147,8 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 					DockerUser:   flagDockerUser,
 					DockerPass:   flagDockerPass,
 					DockerEmail:  flagDockerEmail,
+
+					NoBrowser: flagNoBrowser,
 				}
 
 				if opts.HelmChartVersion == "latest" {
@@ -185,6 +189,8 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	cmd.Flags().StringVar(&flagDockerUser, "docker-username", "", "docker username, can also be specified via "+envDockerEmail)
 	cmd.Flags().StringVar(&flagDockerPass, "docker-password", "", "docker password, can also be specified via "+envDockerPass)
 	cmd.Flags().StringVar(&flagDockerEmail, "docker-email", "", "docker email, can also be specified via "+envDockerEmail)
+
+	cmd.Flags().BoolVar(&flagNoBrowser, "no-browser", false, "disabling attempting to launch the web-browser")
 
 	cmd.MarkFlagsRequiredTogether("docker-username", "docker-password", "docker-email")
 


### PR DESCRIPTION
- fix https://github.com/airbytehq/airbyte-internal-issues/issues/8889
- add support for a `--no-browser` flag
    - if provided, the browser will not attempt to launch
    - this is for situations where a browser may not exist (e.g. installing on an EC2 instance) 