### PR TITLE
chore: deprecate `--host`, add `--external-host`

### DIFF
--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -39,14 +39,17 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 		flagChartVersion    string
 		flagMigrate         bool
 		flagPort            int
-		flagHost            string
 
 		flagDockerServer string
 		flagDockerUser   string
 		flagDockerPass   string
 		flagDockerEmail  string
 
-		flagNoBrowser bool
+		flagNoBrowser    bool
+		flagExternalHost string
+
+		// deprecated
+		flagHost string
 	)
 
 	cmd := &cobra.Command{
@@ -133,6 +136,13 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 					return fmt.Errorf("unable to initialize local command: %w", err)
 				}
 
+				if flagHost != "localhost" {
+					pterm.Warning.Println("The --host flag has been deprecated. Use --external-host instead.")
+					if flagExternalHost != flagHost {
+						flagExternalHost = flagHost
+					}
+				}
+
 				opts := local.InstallOpts{
 					BasicAuthUser:    flagBasicAuthUser,
 					BasicAuthPass:    flagBasicAuthPass,
@@ -141,7 +151,7 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 					Secrets:          flagChartSecrets,
 					Migrate:          flagMigrate,
 					Docker:           dockerClient,
-					Host:             flagHost,
+					Host:             flagExternalHost,
 
 					DockerServer: flagDockerServer,
 					DockerUser:   flagDockerUser,
@@ -178,6 +188,8 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	cmd.Flags().StringVarP(&flagBasicAuthUser, "username", "u", "airbyte", "basic auth username, can also be specified via "+envBasicAuthUser)
 	cmd.Flags().StringVarP(&flagBasicAuthPass, "password", "p", "password", "basic auth password, can also be specified via "+envBasicAuthPass)
 	cmd.Flags().IntVar(&flagPort, "port", local.Port, "ingress http port")
+	cmd.Flags().StringVar(&flagExternalHost, "external-host", "localhost", "ingress http host")
+	// host has been deprecated
 	cmd.Flags().StringVar(&flagHost, "host", "localhost", "ingress http host")
 
 	cmd.Flags().StringVar(&flagChartVersion, "chart-version", "latest", "specify the Airbyte helm chart version to install")

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -190,7 +190,7 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	cmd.Flags().IntVar(&flagPort, "port", local.Port, "ingress http port")
 	cmd.Flags().StringVar(&flagExternalHost, "external-host", "localhost", "ingress http host")
 	// host has been deprecated
-	cmd.Flags().StringVar(&flagHost, "host", "localhost", "ingress http host")
+	cmd.Flags().StringVar(&flagHost, "host", "localhost", "deprecated, use --external-host instead")
 
 	cmd.Flags().StringVar(&flagChartVersion, "chart-version", "latest", "specify the Airbyte helm chart version to install")
 	cmd.Flags().StringVar(&flagChartValuesFile, "values", "", "the Airbyte helm chart values file to load")

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -27,6 +27,9 @@ const (
 	envDockerEmail = "ABCTL_LOCAL_INSTALL_DOCKER_EMAIL"
 )
 
+// defaultHost is the default hostname where the installed Airbyte instance will be accessible.
+const defaultHost = "localhost"
+
 func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	spinner := &pterm.DefaultSpinner
 
@@ -69,9 +72,9 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 			telClient.Attr("docker_arch", dockerVersion.Arch)
 			telClient.Attr("docker_platform", dockerVersion.Platform)
 
-			if flagHost != "localhost" {
+			if flagHost != defaultHost {
 				pterm.Warning.Println("The --host flag has been deprecated. Use --external-host instead.")
-				if flagExternalHost != flagHost {
+				if flagExternalHost == defaultHost {
 					flagExternalHost = flagHost
 				}
 			}
@@ -188,9 +191,9 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	cmd.Flags().StringVarP(&flagBasicAuthUser, "username", "u", "airbyte", "basic auth username, can also be specified via "+envBasicAuthUser)
 	cmd.Flags().StringVarP(&flagBasicAuthPass, "password", "p", "password", "basic auth password, can also be specified via "+envBasicAuthPass)
 	cmd.Flags().IntVar(&flagPort, "port", local.Port, "ingress http port")
-	cmd.Flags().StringVar(&flagExternalHost, "external-host", "localhost", "ingress http host")
+	cmd.Flags().StringVar(&flagExternalHost, "external-host", defaultHost, "ingress http host")
 	// host has been deprecated
-	cmd.Flags().StringVar(&flagHost, "host", "localhost", "deprecated, use --external-host instead")
+	cmd.Flags().StringVar(&flagHost, "host", defaultHost, "deprecated, use --external-host instead")
 
 	cmd.Flags().StringVar(&flagChartVersion, "chart-version", "latest", "specify the Airbyte helm chart version to install")
 	cmd.Flags().StringVar(&flagChartValuesFile, "values", "", "the Airbyte helm chart values file to load")

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -69,8 +69,15 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 			telClient.Attr("docker_arch", dockerVersion.Arch)
 			telClient.Attr("docker_platform", dockerVersion.Platform)
 
+			if flagHost != "localhost" {
+				pterm.Warning.Println("The --host flag has been deprecated. Use --external-host instead.")
+				if flagExternalHost != flagHost {
+					flagExternalHost = flagHost
+				}
+			}
+
 			spinner.UpdateText(fmt.Sprintf("Checking if port %d is available", flagPort))
-			if err := portAvailable(cmd.Context(), flagHost, flagPort); err != nil {
+			if err := portAvailable(cmd.Context(), flagExternalHost, flagPort); err != nil {
 				return fmt.Errorf("port %d is not available: %w", flagPort, err)
 			}
 			return nil
@@ -134,13 +141,6 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 				if err != nil {
 					pterm.Error.Printfln("Failed to initialize 'local' command")
 					return fmt.Errorf("unable to initialize local command: %w", err)
-				}
-
-				if flagHost != "localhost" {
-					pterm.Warning.Println("The --host flag has been deprecated. Use --external-host instead.")
-					if flagExternalHost != flagHost {
-						flagExternalHost = flagHost
-					}
 				}
 
 				opts := local.InstallOpts{


### PR DESCRIPTION
- fix https://github.com/airbytehq/airbyte-internal-issues/issues/8890
- deprecate `--host` flag
- add `--external-host` flag
    - if `--external-host` is specified, use it regardless of `--host`
    - if `--host` is specified, output a deprecation warning and
        - if `--external-host` is specified, use `--external-host`
        - if `--external-host` is not specified, use `--host` 