### PR TITLE
chore: deprecate --username and --password

### DIFF
--- a/internal/cmd/local/local.go
+++ b/internal/cmd/local/local.go
@@ -24,17 +24,17 @@ func NewCmdLocal(provider k8s.Provider) *cobra.Command {
 				return fmt.Errorf("%w: %w", localerr.ErrAirbyteDir, err)
 			}
 
-			// telemetry client configuration
-			{
-				var telOpts []telemetry.GetOption
-				// This is deprecated as the telemetry.Client now checks itself if the DO_NOT_TRACK env-var is defined.
-				// Currently leaving this here to output the message about the --dnt flag no longer being supported.
-				dntFlag, _ := cmd.Flags().GetBool("dnt")
-				if dntFlag {
-					pterm.Warning.Println("The --dnt flag has been deprecated. Use DO_NOT_TRACK environment-variable instead.")
-				}
+			telClient = telemetry.Get()
 
-				telClient = telemetry.Get(telOpts...)
+			{
+				// show the deprecation warning for username and password
+				userFlag, _ := cmd.Flags().GetString("username")
+				passFlag, _ := cmd.Flags().GetString("password")
+				if (userFlag != "" && userFlag != "airbyte") || (passFlag != "" && passFlag != "password") {
+					pterm.Warning.Println("The --username and --password flags have been deprecated.\n" +
+						"  Credentials now are randomly generated and can be retrieved by running\n" +
+						pterm.LightBlue("  abctl local credentials"))
+				}
 			}
 			printProviderDetails(provider)
 

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -201,9 +201,6 @@ func New(provider k8s.Provider, opts ...Option) (*Command, error) {
 }
 
 type InstallOpts struct {
-	BasicAuthUser string
-	BasicAuthPass string
-
 	HelmChartVersion string
 	ValuesFile       string
 	Secrets          []string

--- a/internal/cmd/local/local/cmd_test.go
+++ b/internal/cmd/local/local/cmd_test.go
@@ -180,7 +180,7 @@ func TestCommand_Install(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := c.Install(context.Background(), InstallOpts{BasicAuthUser: "user", BasicAuthPass: "pass"}); err != nil {
+	if err := c.Install(context.Background(), InstallOpts{}); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -340,7 +340,7 @@ func TestCommand_Install_ValuesFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := c.Install(context.Background(), InstallOpts{BasicAuthUser: "user", BasicAuthPass: "pass", ValuesFile: "testdata/values.yml"}); err != nil {
+	if err := c.Install(context.Background(), InstallOpts{ValuesFile: "testdata/values.yml"}); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -364,7 +364,7 @@ func TestCommand_Install_InvalidValuesFile(t *testing.T) {
 
 	valuesFile := "testdata/dne.yml"
 
-	err = c.Install(context.Background(), InstallOpts{BasicAuthUser: "user", BasicAuthPass: "pass", ValuesFile: valuesFile})
+	err = c.Install(context.Background(), InstallOpts{ValuesFile: valuesFile})
 	if err == nil {
 		t.Fatal("expecting an error, received none")
 	}

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -160,7 +160,11 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 					return err
 				}
 
-				spinner.Success("Airbyte installation complete.\nRun: " + pterm.LightBlue("abctl local credentials") + " to retrieve your credentials")
+				spinner.Success(
+					"Airbyte installation complete.\n" +
+						"  A password may be required to login. The password can by found by running\n" +
+						"  the command " + pterm.LightBlue("abctl local credentials"),
+				)
 				return nil
 			})
 		},

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -31,9 +31,6 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	spinner := &pterm.DefaultSpinner
 
 	var (
-		flagBasicAuthUser string
-		flagBasicAuthPass string
-
 		flagChartValuesFile string
 		flagChartSecrets    []string
 		flagChartVersion    string
@@ -134,8 +131,6 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 				}
 
 				opts := local.InstallOpts{
-					BasicAuthUser:    flagBasicAuthUser,
-					BasicAuthPass:    flagBasicAuthPass,
 					HelmChartVersion: flagChartVersion,
 					ValuesFile:       flagChartValuesFile,
 					Secrets:          flagChartSecrets,
@@ -155,8 +150,6 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 					opts.HelmChartVersion = ""
 				}
 
-				envOverride(&opts.BasicAuthUser, envBasicAuthUser)
-				envOverride(&opts.BasicAuthPass, envBasicAuthPass)
 				envOverride(&opts.DockerServer, envDockerServer)
 				envOverride(&opts.DockerUser, envDockerUser)
 				envOverride(&opts.DockerPass, envDockerPass)
@@ -175,8 +168,11 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 
 	cmd.FParseErrWhitelist.UnknownFlags = true
 
-	cmd.Flags().StringVarP(&flagBasicAuthUser, "username", "u", "airbyte", "basic auth username, can also be specified via "+envBasicAuthUser)
-	cmd.Flags().StringVarP(&flagBasicAuthPass, "password", "p", "password", "basic auth password, can also be specified via "+envBasicAuthPass)
+	// The username and password flags are deprecated, but must still be defined so we can check
+	// if they were set in order to issue the deprecated warning.
+	cmd.Flags().StringP("username", "u", "airbyte", "basic auth username, can also be specified via "+envBasicAuthUser)
+	cmd.Flags().StringP("password", "p", "password", "basic auth password, can also be specified via "+envBasicAuthPass)
+
 	cmd.Flags().IntVar(&flagPort, "port", local.Port, "ingress http port")
 	cmd.Flags().StringVar(&flagHost, "host", "localhost", "ingress http host")
 


### PR DESCRIPTION
- deprecate `--username`
- deprecate `--password`
- add deprecation warning output if either `--username` or `--password` is defined
    - include message that these have been replaced with a randomly generated password
    - include message with how to fetch this randomly generated password (`abctl local credentials`) 
- remove deprecation warning for `--dnt`
    - remove all references to `--dnt` 