### PR TITLE
feat: add --external-scheme support

### DIFF
--- a/internal/cmd/local/check.go
+++ b/internal/cmd/local/check.go
@@ -52,7 +52,7 @@ var httpClient doer = &http.Client{Timeout: 3 * time.Second}
 // This function works by attempting to establish a tcp listener on a port.
 // If we can establish a tcp listener on the port, an additional check is made to see if Airbyte may already be
 // bound to that port. If something behinds Airbyte is using it, then treat this as a inaccessible port.
-func portAvailable(ctx context.Context, host string, port int) error {
+func portAvailable(ctx context.Context, scheme, host string, port int) error {
 	if port < 1024 {
 		pterm.Warning.Printfln(
 			"Availability of port %d cannot be determined, as this is a privileged port (less than 1024).\n"+
@@ -68,7 +68,7 @@ func portAvailable(ctx context.Context, host string, port int) error {
 		pterm.Debug.Println(fmt.Sprintf("Unable to listen on port '%d': %s", port, err))
 
 		// check if an existing airbyte installation is already listening on this port
-		req, errInner := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://%s:%d/api/v1/instance_configuration", host, port), nil)
+		req, errInner := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s://%s:%d/api/v1/instance_configuration", scheme, host, port), nil)
 		if errInner != nil {
 			pterm.Error.Printfln("Port %d request could not be created", port)
 			return fmt.Errorf("%w: unable to create request: %w", localerr.ErrPort, err)

--- a/internal/cmd/local/check_test.go
+++ b/internal/cmd/local/check_test.go
@@ -79,7 +79,7 @@ func TestPortAvailable_Available(t *testing.T) {
 		t.Fatal("unable to close listener", err)
 	}
 
-	err = portAvailable(context.Background(), "localhost", p)
+	err = portAvailable(context.Background(), "http", "localhost", p)
 	if err != nil {
 		t.Error("portAvailable returned unexpected error", err)
 	}
@@ -94,7 +94,7 @@ func TestPortAvailable_Unavailable(t *testing.T) {
 	defer listener.Close()
 	p := port(listener.Addr().String())
 
-	err = portAvailable(context.Background(), "localhost", p)
+	err = portAvailable(context.Background(), "http", "localhost", p)
 	// expecting an error
 	if err == nil {
 		t.Error("portAvailable should have returned an error")

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -79,7 +79,7 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 			}
 
 			if flagExternalScheme != "http" && flagExternalScheme != "https" {
-				pterm.Error.Println(fmt.Sprintf("Supported --external-host value '%s', must be http or https", flagExternalScheme))
+				pterm.Error.Println(fmt.Sprintf("Unsupported --external-host value '%s', must be http or https", flagExternalScheme))
 				return errors.New("unsupported scheme for --external-host")
 			}
 


### PR DESCRIPTION
- fix https://github.com/airbytehq/airbyte-internal-issues/issues/8919
- add `--external-scheme` flag
    - for the use-case of running `abctl` on an external host
    - `abctl` needs to know if the external host is reachable via `http` (default) or `https`