### PR TITLE
fix: add second ingress rule

### DIFF
--- a/internal/cmd/local/check.go
+++ b/internal/cmd/local/check.go
@@ -51,7 +51,7 @@ var httpClient doer = &http.Client{Timeout: 3 * time.Second}
 //
 // This function works by attempting to establish a tcp listener on a port.
 // If we can establish a tcp listener on the port, an additional check is made to see if Airbyte may already be
-// bound to that port. If something besides Airbyte is using it, then treat this as a inaccessible port.
+// bound to that port. If something besides Airbyte is using it, treat this as an inaccessible port.
 func portAvailable(ctx context.Context, port int) error {
 	if port < 1024 {
 		pterm.Warning.Printfln(

--- a/internal/cmd/local/check.go
+++ b/internal/cmd/local/check.go
@@ -51,8 +51,8 @@ var httpClient doer = &http.Client{Timeout: 3 * time.Second}
 //
 // This function works by attempting to establish a tcp listener on a port.
 // If we can establish a tcp listener on the port, an additional check is made to see if Airbyte may already be
-// bound to that port. If something behinds Airbyte is using it, then treat this as a inaccessible port.
-func portAvailable(ctx context.Context, host string, port int) error {
+// bound to that port. If something besides Airbyte is using it, then treat this as a inaccessible port.
+func portAvailable(ctx context.Context, port int) error {
 	if port < 1024 {
 		pterm.Warning.Printfln(
 			"Availability of port %d cannot be determined, as this is a privileged port (less than 1024).\n"+
@@ -63,12 +63,12 @@ func portAvailable(ctx context.Context, host string, port int) error {
 
 	// net.Listen doesn't support providing a context
 	lc := &net.ListenConfig{}
-	listener, err := lc.Listen(ctx, "tcp", fmt.Sprintf("%s:%d", host, port))
+	listener, err := lc.Listen(ctx, "tcp", fmt.Sprintf("localhost:%d", port))
 	if err != nil {
 		pterm.Debug.Println(fmt.Sprintf("Unable to listen on port '%d': %s", port, err))
 
 		// check if an existing airbyte installation is already listening on this port
-		req, errInner := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://%s:%d/api/v1/instance_configuration", host, port), nil)
+		req, errInner := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d/api/v1/instance_configuration", port), nil)
 		if errInner != nil {
 			pterm.Error.Printfln("Port %d request could not be created", port)
 			return fmt.Errorf("%w: unable to create request: %w", localerr.ErrPort, err)

--- a/internal/cmd/local/check_test.go
+++ b/internal/cmd/local/check_test.go
@@ -79,7 +79,7 @@ func TestPortAvailable_Available(t *testing.T) {
 		t.Fatal("unable to close listener", err)
 	}
 
-	err = portAvailable(context.Background(), "localhost", p)
+	err = portAvailable(context.Background(), p)
 	if err != nil {
 		t.Error("portAvailable returned unexpected error", err)
 	}
@@ -94,7 +94,7 @@ func TestPortAvailable_Unavailable(t *testing.T) {
 	defer listener.Close()
 	p := port(listener.Addr().String())
 
-	err = portAvailable(context.Background(), "localhost", p)
+	err = portAvailable(context.Background(), p)
 	// expecting an error
 	if err == nil {
 		t.Error("portAvailable should have returned an error")

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -440,7 +440,8 @@ func (c *Command) Install(ctx context.Context, opts InstallOpts) error {
 		return err
 	}
 
-	url := fmt.Sprintf("http://%s:%d", opts.Host, c.portHTTP)
+	// verify ingress using localhost
+	url := fmt.Sprintf("http://localhost:%d", c.portHTTP)
 	if err := c.verifyIngress(ctx, url); err != nil {
 		return err
 	}

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -64,7 +64,7 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 			telClient.Attr("docker_platform", dockerVersion.Platform)
 
 			spinner.UpdateText(fmt.Sprintf("Checking if port %d is available", flagPort))
-			if err := portAvailable(cmd.Context(), flagHost, flagPort); err != nil {
+			if err := portAvailable(cmd.Context(), flagPort); err != nil {
 				return fmt.Errorf("port %d is not available: %w", flagPort, err)
 			}
 			return nil


### PR DESCRIPTION
- fix https://github.com/airbytehq/airbyte-internal-issues/issues/8932
- In order to support non-local installations (i.e. EC2 instances)
    - always create a `localhost` ingress-rule
    - if `--host` was defined, create an additional `--host` ingress-rule