### PR TITLE
fix: support DOCKER_HOST

### DIFF
--- a/internal/cmd/local/docker/docker.go
+++ b/internal/cmd/local/docker/docker.go
@@ -123,7 +123,9 @@ func newWithOptions(ctx context.Context, newPing newPing, goos string) (*Docker,
 
 // createAndPing attempts to create a docker client and ping it to ensure we can communicate
 func createAndPing(ctx context.Context, newPing newPing, host string, opts []client.Opt) (Client, error) {
-	cli, err := newPing(append(opts, client.WithHost(host))...)
+	// Pass client.WithHost first to ensure it runs prior to the client.FromEnv call.
+	// We want the DOCKER_HOST to be used if it has been specified, overriding our host.
+	cli, err := newPing(append([]client.Opt{client.WithHost(host)}, opts...)...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create docker client: %w", err)
 	}
@@ -147,7 +149,6 @@ func (d *Docker) Version(ctx context.Context) (Version, error) {
 		Arch:     ver.Arch,
 		Platform: ver.Platform.Name,
 	}, nil
-
 }
 
 // Port returns the host-port the underlying docker process is currently bound to, for the given container.


### PR DESCRIPTION
- fix https://github.com/airbytehq/airbyte-internal-issues/issues/8933
- change the priority order of options used when creating the docker client
    - previously `WithHost` ran last which ensured that the `host` we defined was the one used
    - now `WithHost` runs first, so that the `FromEnv` call can override the host correctly if `DOCKER_HOST` is defined
       - this addresses an issue where the wrong host is being used and the user has no way to override this host
    - the docker cli has no concept of `docker context`, otherwise the host could been fetched from the active `docker context`