### PR TITLE
fix: k8s warnings being handled improperly 

### DIFF
--- a/internal/cmd/local/k8s/log.go
+++ b/internal/cmd/local/k8s/log.go
@@ -1,0 +1,22 @@
+package k8s
+
+import (
+	"fmt"
+	"github.com/pterm/pterm"
+	"k8s.io/client-go/rest"
+)
+
+var _ rest.WarningHandler = (*Logger)(nil)
+
+// Logger is an implementation of the WarningHandler that converts the k8s warning messages
+// into abctl debug messages.
+type Logger struct {
+}
+
+func (x Logger) HandleWarningHeader(code int, _ string, msg string) {
+	// code and length check are taken from the default WarningLogger implementation
+	if code != 299 || len(msg) == 0 {
+		return
+	}
+	pterm.Debug.Println(fmt.Sprintf("k8s - WARN: %s", msg))
+}

--- a/internal/cmd/local/k8s/log_test.go
+++ b/internal/cmd/local/k8s/log_test.go
@@ -1,0 +1,56 @@
+package k8s
+
+import (
+	"bytes"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pterm/pterm"
+	"os"
+	"testing"
+)
+
+func TestLogger_HandleWarningHeader(t *testing.T) {
+	b := bytes.NewBufferString("")
+	pterm.SetDefaultOutput(b)
+	pterm.EnableDebugMessages()
+	// remove color codes from output
+	pterm.DisableColor()
+	t.Cleanup(func() {
+		pterm.SetDefaultOutput(os.Stdout)
+		pterm.DisableDebugMessages()
+		pterm.EnableColor()
+	})
+
+	tests := []struct {
+		name string
+		code int
+		msg  string
+		want string
+	}{
+		{
+			name: "non 299 code",
+			code: 300,
+			msg:  "test msg",
+		},
+		{
+			name: "empty msg",
+			code: 299,
+		},
+		{
+			name: "happy path",
+			code: 299,
+			msg:  "test msg",
+			want: "  DEBUG   k8s - WARN: test msg\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := Logger{}
+			logger.HandleWarningHeader(tt.code, "", tt.msg)
+
+			if d := cmp.Diff(tt.want, b.String()); d != "" {
+				t.Error("unexpected output (-want, +got) =", d)
+			}
+		})
+	}
+}

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -12,6 +12,7 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/rest"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -776,6 +777,7 @@ func (c *Command) launch(url string) {
 
 // defaultK8s returns the default k8s client
 func defaultK8s(kubecfg, kubectx string) (k8s.Client, error) {
+	rest.SetDefaultWarningHandler(k8s.Logger{})
 	k8sCfg, err := k8sClientConfig(kubecfg, kubectx)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", localerr.ErrKubernetes, err)

--- a/internal/cmd/version/version_test.go
+++ b/internal/cmd/version/version_test.go
@@ -2,7 +2,6 @@ package version
 
 import (
 	"bytes"
-	"fmt"
 	"github.com/airbytehq/abctl/internal/build"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pterm/pterm"
@@ -14,7 +13,6 @@ func TestCmd_Output(t *testing.T) {
 	b := bytes.NewBufferString("")
 	pterm.SetDefaultOutput(b)
 	t.Cleanup(func() {
-		fmt.Println("outer cleanup")
 		pterm.SetDefaultOutput(os.Stdout)
 	})
 


### PR DESCRIPTION
- add a `k8s.Logger`
    - prior to this change k8s warnings were sent directly to stdout
    - after this change, k8s warnings will now be treated as debug output
        - only be visible by passing the `-v` flag