### PR TITLE
fix: run `brew update` before attempting to upgrade

### DIFF
--- a/abctl_install.sh
+++ b/abctl_install.sh
@@ -225,6 +225,7 @@ _install_darwin() {
     if ! _exists brew; then
         _install_binary darwin "$(_get_arch)"
     elif brew ls --version abctl > /dev/null; then
+        brew update
         brew upgrade abctl
     else
         brew tap airbytehq/tap


### PR DESCRIPTION
For some reasons `brew` doesn't pick up the the latest version of `abctl` on our tap. Running update seems to fix it.

Not sure if this is the right fix.