### PR TITLE
feat: support for custom volume mounts

### DIFF
--- a/internal/cmd/local/k8s/kind/config.go
+++ b/internal/cmd/local/k8s/kind/config.go
@@ -9,7 +9,7 @@ type Config struct {
 }
 
 type Node struct {
-	Role   NodeRole          `yaml:"role"`
+	Role   string            `yaml:"role"`
 	Image  string            `yaml:"image"`
 	Labels map[string]string `yaml:"labels"`
 
@@ -24,25 +24,19 @@ type Node struct {
 }
 
 type Mount struct {
-	ContainerPath  string           `yaml:"containerPath"`
-	HostPath       string           `yaml:"hostPath"`
-	ReadOnly       bool             `yaml:"readOnly"`
-	SelinuxRelabel bool             `yaml:"selinuxRelabel"`
-	Propagation    MountPropagation `yaml:"propagation"`
+	ContainerPath  string `yaml:"containerPath"`
+	HostPath       string `yaml:"hostPath"`
+	ReadOnly       bool   `yaml:"readOnly"`
+	SelinuxRelabel bool   `yaml:"selinuxRelabel"`
+	Propagation    string `yaml:"propagation"`
 }
-
-type MountPropagation string
-
-type NodeRole string
 
 type PortMapping struct {
-	ContainerPort int32               `yaml:"containerPort"`
-	HostPort      int32               `yaml:"hostPort"`
-	ListenAddress string              `yaml:"listenAddress"`
-	Protocol      PortMappingProtocol `yaml:"protocol"`
+	ContainerPort int32  `yaml:"containerPort"`
+	HostPort      int32  `yaml:"hostPort"`
+	ListenAddress string `yaml:"listenAddress"`
+	Protocol      string `yaml:"protocol"`
 }
-
-type PortMappingProtocol string
 
 func DefaultConfig() *Config {
 	kubeadmConfigPatch := `kind: InitConfiguration
@@ -60,7 +54,7 @@ nodeRegistration:
 				ExtraMounts: []Mount{
 					{
 						HostPath:      paths.Data,
-						ContainerPath: "/var/local-path-provider",
+						ContainerPath: "/var/local-path-provisioner",
 					},
 				},
 				ExtraPortMappings: []PortMapping{

--- a/internal/cmd/local/k8s/kind/config.go
+++ b/internal/cmd/local/k8s/kind/config.go
@@ -1,0 +1,87 @@
+package kind
+
+import "github.com/airbytehq/abctl/internal/cmd/local/paths"
+
+type Config struct {
+	Kind       string `yaml:"kind"`
+	ApiVersion string `yaml:"apiVersion"`
+	Nodes      []Node `yaml:"nodes"`
+}
+
+type Node struct {
+	Role   NodeRole          `yaml:"role"`
+	Image  string            `yaml:"image"`
+	Labels map[string]string `yaml:"labels"`
+
+	ExtraMounts       []Mount       `yaml:"extraMounts"`
+	ExtraPortMappings []PortMapping `yaml:"extraPortMappings"`
+
+	// KubeadmConfigPatches are applied to the generated kubeadm config as
+	// strategic merge patches to `kustomize build` internally
+	// https://github.com/kubernetes/community/blob/a9cf5c8f3380bb52ebe57b1e2dbdec136d8dd484/contributors/devel/sig-api-machinery/strategic-merge-patch.md
+	// This should be an inline yaml blob-string
+	KubeadmConfigPatches []string `yaml:"kubeadmConfigPatches"`
+}
+
+type Mount struct {
+	ContainerPath  string           `yaml:"containerPath"`
+	HostPath       string           `yaml:"hostPath"`
+	ReadOnly       bool             `yaml:"readOnly"`
+	SelinuxRelabel bool             `yaml:"selinuxRelabel"`
+	Propagation    MountPropagation `yaml:"propagation"`
+}
+
+type MountPropagation string
+
+type NodeRole string
+
+type PortMapping struct {
+	ContainerPort int32               `yaml:"containerPort"`
+	HostPort      int32               `yaml:"hostPort"`
+	ListenAddress string              `yaml:"listenAddress"`
+	Protocol      PortMappingProtocol `yaml:"protocol"`
+}
+
+type PortMappingProtocol string
+
+func DefaultConfig() *Config {
+	kubeadmConfigPatch := `kind: InitConfiguration
+nodeRegistration:
+  kubeletExtraArgs:
+    node-labels: "ingress-ready=true"`
+
+	cfg := &Config{
+		Kind:       "Cluster",
+		ApiVersion: "kind.x-k8s.io/v1alpha4",
+		Nodes: []Node{
+			{
+				Role:                 "control-plane",
+				KubeadmConfigPatches: []string{kubeadmConfigPatch},
+				ExtraMounts: []Mount{
+					{
+						HostPath:      paths.Data,
+						ContainerPath: "/var/local-path-provider",
+					},
+				},
+				ExtraPortMappings: []PortMapping{
+					{
+						ContainerPort: 80,
+						HostPort:      8000,
+					},
+				},
+			},
+		},
+	}
+
+	return cfg
+}
+
+func (c *Config) WithVolumeMount(hostPath string, containerPath string) *Config {
+	c.Nodes[0].ExtraMounts = append(c.Nodes[0].ExtraMounts, Mount{HostPath: hostPath, ContainerPath: containerPath})
+	return c
+}
+
+func (c *Config) WithHostPort(port int) *Config {
+	c.Nodes[0].ExtraPortMappings[0].HostPort = int32(port)
+	return c
+}

--- a/internal/cmd/local/k8s/kind/config.go
+++ b/internal/cmd/local/k8s/kind/config.go
@@ -1,6 +1,11 @@
 package kind
 
-import "github.com/airbytehq/abctl/internal/cmd/local/paths"
+import (
+	"github.com/airbytehq/abctl/internal/cmd/local/paths"
+)
+
+// IngressPort is the default port that Airbyte will deploy to.
+const IngressPort = 8000
 
 type Config struct {
 	Kind       string `yaml:"kind"`
@@ -60,7 +65,7 @@ nodeRegistration:
 				ExtraPortMappings: []PortMapping{
 					{
 						ContainerPort: 80,
-						HostPort:      8000,
+						HostPort:      IngressPort,
 					},
 				},
 			},

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/airbytehq/abctl/internal/cmd/local/docker"
 	"github.com/airbytehq/abctl/internal/cmd/local/helm"
+	"github.com/airbytehq/abctl/internal/cmd/local/k8s/kind"
 	"github.com/airbytehq/abctl/internal/cmd/local/migrate"
 	"github.com/airbytehq/abctl/internal/cmd/local/paths"
 	"github.com/airbytehq/abctl/internal/maps"
@@ -50,9 +51,6 @@ const (
 	nginxRepoName       = "nginx"
 	nginxRepoURL        = "https://kubernetes.github.io/ingress-nginx"
 )
-
-// Port is the default port that Airbyte will deploy to.
-const Port = 8000
 
 // dockerAuthSecretName is the name of the secret which holds the docker authentication information.
 const dockerAuthSecretName = "docker-auth"
@@ -153,7 +151,7 @@ func New(provider k8s.Provider, opts ...Option) (*Command, error) {
 	}
 
 	if c.portHTTP == 0 {
-		c.portHTTP = Port
+		c.portHTTP = kind.IngressPort
 	}
 
 	// set k8s client, if not defined

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -203,12 +203,11 @@ func New(provider k8s.Provider, opts ...Option) (*Command, error) {
 }
 
 type InstallOpts struct {
-	HelmChartVersion  string
-	ValuesFile        string
-	Secrets           []string
-	ExtraVolumeMounts []string
-	Migrate           bool
-	Host              string
+	HelmChartVersion string
+	ValuesFile       string
+	Secrets          []string
+	Migrate          bool
+	Host             string
 
 	Docker *docker.Docker
 

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -3,6 +3,13 @@ package local
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/airbytehq/abctl/internal/cmd/local/docker"
 	"github.com/airbytehq/abctl/internal/cmd/local/helm"
 	"github.com/airbytehq/abctl/internal/cmd/local/migrate"
@@ -13,12 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/rest"
-	"net/http"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
 	"github.com/airbytehq/abctl/internal/cmd/local/localerr"
@@ -202,11 +203,12 @@ func New(provider k8s.Provider, opts ...Option) (*Command, error) {
 }
 
 type InstallOpts struct {
-	HelmChartVersion string
-	ValuesFile       string
-	Secrets          []string
-	Migrate          bool
-	Host             string
+	HelmChartVersion  string
+	ValuesFile        string
+	Secrets           []string
+	ExtraVolumeMounts []string
+	Migrate           bool
+	Host              string
 
 	Docker *docker.Docker
 

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -199,7 +199,7 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	cmd.Flags().StringVar(&flagChartVersion, "chart-version", "latest", "specify the Airbyte helm chart version to install")
 	cmd.Flags().StringVar(&flagChartValuesFile, "values", "", "the Airbyte helm chart values file to load")
 	cmd.Flags().StringSliceVar(&flagChartSecrets, "secret", []string{}, "an Airbyte helm chart secret file")
-	cmd.Flags().StringSliceVar(&flagExtraVolumeMounts, "volume", []string{}, "additional volume mounts (format: <host_path>:<guest_path>)")
+	cmd.Flags().StringSliceVar(&flagExtraVolumeMounts, "volume", []string{}, "additional volume mounts (format: <HOST_PATH>:<GUEST_PATH>)")
 	cmd.Flags().BoolVar(&flagMigrate, "migrate", false, "migrate data from docker compose installation")
 
 	cmd.Flags().StringVar(&flagDockerServer, "docker-server", "https://index.docker.io/v1/", "docker registry, can also be specified via "+envDockerServer)

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/airbytehq/abctl/internal/cmd/local/docker"
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
+	"github.com/airbytehq/abctl/internal/cmd/local/k8s/kind"
 	"github.com/airbytehq/abctl/internal/cmd/local/local"
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/pterm/pterm"
@@ -193,7 +194,7 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	_ = cmd.Flags().MarkHidden("username")
 	_ = cmd.Flags().MarkHidden("password")
 
-	cmd.Flags().IntVar(&flagPort, "port", local.Port, "ingress http port")
+	cmd.Flags().IntVar(&flagPort, "port", kind.IngressPort, "ingress http port")
 	cmd.Flags().StringVar(&flagHost, "host", "localhost", "ingress http host")
 
 	cmd.Flags().StringVar(&flagChartVersion, "chart-version", "latest", "specify the Airbyte helm chart version to install")

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -2,13 +2,15 @@ package local
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/airbytehq/abctl/internal/cmd/local/docker"
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
 	"github.com/airbytehq/abctl/internal/cmd/local/local"
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 const (
@@ -27,16 +29,22 @@ const (
 	envDockerEmail = "ABCTL_LOCAL_INSTALL_DOCKER_EMAIL"
 )
 
+type VolumeMount struct {
+	Path     string
+	HostPath string
+}
+
 func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	spinner := &pterm.DefaultSpinner
 
 	var (
-		flagChartValuesFile string
-		flagChartSecrets    []string
-		flagChartVersion    string
-		flagMigrate         bool
-		flagPort            int
-		flagHost            string
+		flagChartValuesFile   string
+		flagChartSecrets      []string
+		flagChartVersion      string
+		flagMigrate           bool
+		flagPort              int
+		flagHost              string
+		flagExtraVolumeMounts []string
 
 		flagDockerServer string
 		flagDockerUser   string
@@ -113,7 +121,13 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 					// no existing cluster, need to create one
 					pterm.Info.Println(fmt.Sprintf("No existing cluster found, cluster '%s' will be created", provider.ClusterName))
 					spinner.UpdateText(fmt.Sprintf("Creating cluster '%s'", provider.ClusterName))
-					if err := cluster.Create(flagPort); err != nil {
+
+					extraVolumeMounts, err := parseVolumeMounts(flagExtraVolumeMounts)
+					if err != nil {
+						return err
+					}
+
+					if err := cluster.Create(flagPort, extraVolumeMounts); err != nil {
 						pterm.Error.Printfln("Cluster '%s' could not be created", provider.ClusterName)
 						return err
 					}
@@ -185,6 +199,7 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	cmd.Flags().StringVar(&flagChartVersion, "chart-version", "latest", "specify the Airbyte helm chart version to install")
 	cmd.Flags().StringVar(&flagChartValuesFile, "values", "", "the Airbyte helm chart values file to load")
 	cmd.Flags().StringSliceVar(&flagChartSecrets, "secret", []string{}, "an Airbyte helm chart secret file")
+	cmd.Flags().StringSliceVar(&flagExtraVolumeMounts, "volume", []string{}, "additional volume mounts (format: <host_path>:<guest_path>)")
 	cmd.Flags().BoolVar(&flagMigrate, "migrate", false, "migrate data from docker compose installation")
 
 	cmd.Flags().StringVar(&flagDockerServer, "docker-server", "https://index.docker.io/v1/", "docker registry, can also be specified via "+envDockerServer)
@@ -206,4 +221,25 @@ func envOverride(original *string, env string) {
 	if v := os.Getenv(env); v != "" {
 		*original = v
 	}
+}
+
+func parseVolumeMounts(specs []string) ([]k8s.ExtraVolumeMount, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+
+	mounts := make([]k8s.ExtraVolumeMount, len(specs))
+
+	for i, spec := range specs {
+		parts := strings.Split(spec, ":")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("volume %s is not a valid volume spec, must be <HOST_PATH>:<GUEST_PATH>", spec)
+		}
+		mounts[i] = k8s.ExtraVolumeMount{
+			HostPath:      parts[0],
+			ContainerPath: parts[1],
+		}
+	}
+
+	return mounts, nil
 }

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -225,10 +225,6 @@ func envOverride(original *string, env string) {
 }
 
 func parseVolumeMounts(specs []string) ([]k8s.ExtraVolumeMount, error) {
-	if len(specs) == 0 {
-		return nil, nil
-	}
-
 	mounts := make([]k8s.ExtraVolumeMount, len(specs))
 
 	for i, spec := range specs {


### PR DESCRIPTION
This PR adds support for adding arbitrary extra volume mounts to the Kind cluster node. This makes it possible for developers who need/want to mount host volumes for iterating on services they develop (e.g. connector-builder)

Usage:
`abctl local install --volume /Users/angel/Developer/github/airbytehq/airbyte/airbyte-integrations/connectors:/mnt/connectors --values values.yaml`

`--volume` allows you to specify any arbitrary volume mount  and in conjunction with your own values.yaml you can specify the mounts you need:

example:

```
connector-builder-server:
  env_vars:
    PATH_TO_CONNECTORS: "/connectors"
  extraVolumes:
    - name: "connectors"
      hostPath:
        path: "/mnt/connectors"
        type: DirectoryOrCreate
  extraVolumeMounts:
    - name: "connectors"
      mountPath: /connectors

server: 
  env_vars:
    PATH_TO_CONNECTORS: "/connectors"
  extraVolumes:
    - name: "connectors"
      hostPath:
        path: "/mnt/connectors"
        type: DirectoryOrCreate
  extraVolumeMounts:
    - name: "connectors"
      mountPath: /connectors
```