### PR TITLE
feat: add a `--low-resource-mode` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Installs a local Airbyte instance or updates an existing installation which was 
 | --secret          | ""        | **Can be set multiple times**.<br />Creates a kubernetes secret based on the contents of the file provided.<br />Useful when used in conjunction with `--values` for customizing installation.                                                         |
 | --values          | ""        | Helm values file to further customize the Airbyte installation.                                                                                                                                                                                        |
 | --volume          | ""        | **Can be set multiple times**.<br />Mounts additional volumes in the kubernetes cluster.<br />Must be in the format of `<HOST_PATH>:<GUEST_PATH>`.                                                                                                     |
+| --low-resource-mode          | false        | Run Airbyte in low resource mode.              |
+
 
 
 ### status

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -214,8 +214,8 @@ type InstallOpts struct {
 	DockerPass   string
 	DockerEmail  string
 
-	NoBrowser          bool
-	LowResourceProfile bool
+	NoBrowser       bool
+	LowResourceMode bool
 }
 
 func (i *InstallOpts) dockerAuth() bool {
@@ -353,7 +353,7 @@ func (c *Command) Install(ctx context.Context, opts InstallOpts) error {
 		"global.auth.enabled=true",
 	}
 
-	if opts.LowResourceProfile {
+	if opts.LowResourceMode {
 		airbyteValues = append(airbyteValues,
 			"global.jobs.resources.requests.cpu=1m",
 			"global.jobs.resources.requests.memory=128m",

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -214,7 +214,8 @@ type InstallOpts struct {
 	DockerPass   string
 	DockerEmail  string
 
-	NoBrowser bool
+	NoBrowser          bool
+	LowResourceProfile bool
 }
 
 func (i *InstallOpts) dockerAuth() bool {
@@ -349,9 +350,21 @@ func (c *Command) Install(ctx context.Context, opts InstallOpts) error {
 
 	airbyteValues := []string{
 		"global.env_vars.AIRBYTE_INSTALLATION_ID=" + telUser,
-		"global.jobs.resources.limits.cpu=3",
-		"global.jobs.resources.limits.memory=4Gi",
 		"global.auth.enabled=true",
+	}
+
+	if opts.LowResourceProfile {
+		airbyteValues = append(airbyteValues,
+			"global.jobs.resources.requests.cpu=1m",
+			"global.jobs.resources.requests.memory=128m",
+		)
+	} else {
+		airbyteValues = append(airbyteValues,
+			"global.jobs.resources.limits.cpu=3",
+			"global.jobs.resources.limits.memory=4Gi",
+			"global.jobs.resources.requests.cpu=1m",
+			"global.jobs.resources.requests.memory=128m",
+		)
 	}
 
 	if opts.dockerAuth() {

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -362,8 +362,6 @@ func (c *Command) Install(ctx context.Context, opts InstallOpts) error {
 		airbyteValues = append(airbyteValues,
 			"global.jobs.resources.limits.cpu=3",
 			"global.jobs.resources.limits.memory=4Gi",
-			"global.jobs.resources.requests.cpu=1m",
-			"global.jobs.resources.requests.memory=128m",
 		)
 	}
 

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -52,7 +52,8 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 		flagDockerPass   string
 		flagDockerEmail  string
 
-		flagNoBrowser bool
+		flagNoBrowser          bool
+		flagLowResourceProfile bool
 	)
 
 	cmd := &cobra.Command{
@@ -158,7 +159,8 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 					DockerPass:   flagDockerPass,
 					DockerEmail:  flagDockerEmail,
 
-					NoBrowser: flagNoBrowser,
+					NoBrowser:          flagNoBrowser,
+					LowResourceProfile: flagLowResourceProfile,
 				}
 
 				if opts.HelmChartVersion == "latest" {
@@ -209,6 +211,7 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	cmd.Flags().StringVar(&flagDockerEmail, "docker-email", "", "docker email, can also be specified via "+envDockerEmail)
 
 	cmd.Flags().BoolVar(&flagNoBrowser, "no-browser", false, "disable launching the web-browser post install")
+	cmd.Flags().BoolVar(&flagLowResourceProfile, "low-resource-profile", false, "run Airbyte with the minimal resource profile")
 
 	cmd.MarkFlagsRequiredTogether("docker-username", "docker-password", "docker-email")
 

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -52,8 +52,8 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 		flagDockerPass   string
 		flagDockerEmail  string
 
-		flagNoBrowser          bool
-		flagLowResourceProfile bool
+		flagNoBrowser       bool
+		flagLowResourceMode bool
 	)
 
 	cmd := &cobra.Command{
@@ -159,8 +159,8 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 					DockerPass:   flagDockerPass,
 					DockerEmail:  flagDockerEmail,
 
-					NoBrowser:          flagNoBrowser,
-					LowResourceProfile: flagLowResourceProfile,
+					NoBrowser:       flagNoBrowser,
+					LowResourceMode: flagLowResourceMode,
 				}
 
 				if opts.HelmChartVersion == "latest" {
@@ -211,7 +211,7 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	cmd.Flags().StringVar(&flagDockerEmail, "docker-email", "", "docker email, can also be specified via "+envDockerEmail)
 
 	cmd.Flags().BoolVar(&flagNoBrowser, "no-browser", false, "disable launching the web-browser post install")
-	cmd.Flags().BoolVar(&flagLowResourceProfile, "low-resource-profile", false, "run Airbyte with a low resource profile")
+	cmd.Flags().BoolVar(&flagLowResourceMode, "low-resource-mode", false, "run Airbyte in low resource mode")
 
 	cmd.MarkFlagsRequiredTogether("docker-username", "docker-password", "docker-email")
 

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -211,7 +211,7 @@ func NewCmdInstall(provider k8s.Provider) *cobra.Command {
 	cmd.Flags().StringVar(&flagDockerEmail, "docker-email", "", "docker email, can also be specified via "+envDockerEmail)
 
 	cmd.Flags().BoolVar(&flagNoBrowser, "no-browser", false, "disable launching the web-browser post install")
-	cmd.Flags().BoolVar(&flagLowResourceProfile, "low-resource-profile", false, "run Airbyte with the minimal resource profile")
+	cmd.Flags().BoolVar(&flagLowResourceProfile, "low-resource-profile", false, "run Airbyte with a low resource profile")
 
 	cmd.MarkFlagsRequiredTogether("docker-username", "docker-password", "docker-email")
 


### PR DESCRIPTION
This PR adds support for a new `--low-resource-mode` mode that you can enable when running local install of Airbyte. 
This is useful when running in environments that have less resources. 