### PR TITLE
fix: if email is not defined, make it more clear

### DIFF
--- a/internal/cmd/local/local_credentials.go
+++ b/internal/cmd/local/local_credentials.go
@@ -93,6 +93,9 @@ func NewCmdCredentials(provider k8s.Provider) *cobra.Command {
 					pterm.Error.Println("Unable to determine organization email")
 					return fmt.Errorf("unable to determine organization email: %w", err)
 				}
+				if orgEmail == "" {
+					orgEmail = "[not set]"
+				}
 
 				pterm.Success.Println(fmt.Sprintf("Retreiving your credentials from '%s'", secret.Name))
 				pterm.Info.Println(fmt.Sprintf(`Credentials:


### PR DESCRIPTION
Instead of displaying
```
 SUCCESS  Retreiving your credentials from 'airbyte-auth-secrets'
  INFO    Credentials:
            Email:
            Password: *******
            Client-Id: *******
            Client-Secret: *******
```
display
```
 SUCCESS  Retreiving your credentials from 'airbyte-auth-secrets'
  INFO    Credentials:
            Email: [not set]
            Password: *******
            Client-Id: *******
            Client-Secret: *******
```