### PR TITLE
feat: replace cobra with kong

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/airbytehq/abctl
 go 1.22.2
 
 require (
+	github.com/alecthomas/kong v0.9.0
 	github.com/cli/browser v1.3.0
 	github.com/docker/docker v27.1.1+incompatible
 	github.com/docker/go-connections v0.5.0
@@ -13,7 +14,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc6
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pterm/pterm v0.12.79
-	github.com/spf13/cobra v1.8.0
 	golang.org/x/mod v0.17.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.14.2
@@ -129,6 +129,7 @@ require (
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
+	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,12 @@ github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7
 github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
+github.com/alecthomas/assert/v2 v2.6.0 h1:o3WJwILtexrEUk3cUVal3oiQY2tfgr/FHWiz/v2n4FU=
+github.com/alecthomas/assert/v2 v2.6.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
+github.com/alecthomas/kong v0.9.0 h1:G5diXxc85KvoV2f0ZRVuMsi45IrBgx9zDNGNj165aPA=
+github.com/alecthomas/kong v0.9.0/go.mod h1:Y47y5gKfHp1hDc7CH7OeXgLIpp+Q2m1Ni0L5s3bI8Os=
+github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
+github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
@@ -211,6 +217,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
 	"github.com/airbytehq/abctl/internal/cmd/local/localerr"
 	"github.com/airbytehq/abctl/internal/cmd/version"
+	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/alecthomas/kong"
 	"github.com/pterm/pterm"
 )
@@ -86,11 +87,11 @@ type Cmd struct {
 }
 
 func (c *Cmd) BeforeApply(ctx *kong.Context) error {
-	//fmt.Println("root before apply")
 	if _, envVarDNT := os.LookupEnv("DO_NOT_TRACK"); envVarDNT {
 		pterm.Info.Println("Telemetry collection disabled (DO_NOT_TRACK)")
 	}
 	ctx.BindTo(k8s.DefaultProvider, (*k8s.Provider)(nil))
+	ctx.BindTo(telemetry.Get(), (*telemetry.Client)(nil))
 
 	return nil
 }

--- a/internal/cmd/local/local.go
+++ b/internal/cmd/local/local.go
@@ -9,11 +9,8 @@ import (
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
 	"github.com/airbytehq/abctl/internal/cmd/local/localerr"
 	"github.com/airbytehq/abctl/internal/cmd/local/paths"
-	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/pterm/pterm"
 )
-
-var telClient telemetry.Client
 
 type Cmd struct {
 	Credentials CredentialsCmd `cmd:"" help:"Get local Airbyte user credentials."`
@@ -27,7 +24,7 @@ func (c *Cmd) BeforeApply() error {
 		return fmt.Errorf("%w: %w", localerr.ErrAirbyteDir, err)
 	}
 
-	telClient = telemetry.Get()
+	//telClient = telemetry.Get()
 	return nil
 }
 

--- a/internal/cmd/local/local.go
+++ b/internal/cmd/local/local.go
@@ -24,7 +24,6 @@ func (c *Cmd) BeforeApply() error {
 		return fmt.Errorf("%w: %w", localerr.ErrAirbyteDir, err)
 	}
 
-	//telClient = telemetry.Get()
 	return nil
 }
 

--- a/internal/cmd/local/local.go
+++ b/internal/cmd/local/local.go
@@ -11,32 +11,29 @@ import (
 	"github.com/airbytehq/abctl/internal/cmd/local/paths"
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/pterm/pterm"
-	"github.com/spf13/cobra"
 )
 
 var telClient telemetry.Client
 
-// NewCmdLocal represents the local command.
-func NewCmdLocal(provider k8s.Provider) *cobra.Command {
-	cmd := &cobra.Command{
-		Use: "local",
-		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			if err := checkAirbyteDir(); err != nil {
-				return fmt.Errorf("%w: %w", localerr.ErrAirbyteDir, err)
-			}
+type Cmd struct {
+	Credentials CredentialsCmd `cmd:"" help:"Get local Airbyte user credentials."`
+	Install     InstallCmd     `cmd:"" help:"Install local Airbyte."`
+	Status      StatusCmd      `cmd:"" help:"Get local Airbyte status."`
+	Uninstall   UninstallCmd   `cmd:"" help:"Uninstall local Airbyte."`
+}
 
-			telClient = telemetry.Get()
-
-			printProviderDetails(provider)
-
-			return nil
-		},
-		Short: "Manages local Airbyte installations",
+func (c *Cmd) BeforeApply() error {
+	if err := checkAirbyteDir(); err != nil {
+		return fmt.Errorf("%w: %w", localerr.ErrAirbyteDir, err)
 	}
 
-	cmd.AddCommand(NewCmdInstall(provider), NewCmdUninstall(provider), NewCmdStatus(provider), NewCmdCredentials(provider))
+	telClient = telemetry.Get()
+	return nil
+}
 
-	return cmd
+func (c *Cmd) AfterApply(provider k8s.Provider) error {
+	printProviderDetails(provider)
+	return nil
 }
 
 func printProviderDetails(p k8s.Provider) {

--- a/internal/cmd/local/local_credentials.go
+++ b/internal/cmd/local/local_credentials.go
@@ -27,7 +27,7 @@ type CredentialsCmd struct {
 	Password string `help:"Specify a new password to use for authentication."`
 }
 
-func (cc *CredentialsCmd) Run(ctx context.Context, provider k8s.Provider) error {
+func (cc *CredentialsCmd) Run(ctx context.Context, provider k8s.Provider, telClient telemetry.Client) error {
 	spinner := &pterm.DefaultSpinner
 
 	return telClient.Wrap(ctx, telemetry.Credentials, func() error {

--- a/internal/cmd/local/local_credentials.go
+++ b/internal/cmd/local/local_credentials.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/airbytehq/abctl/internal/cmd/local/airbyte"
@@ -8,7 +9,6 @@ import (
 	"github.com/airbytehq/abctl/internal/cmd/local/localerr"
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/pterm/pterm"
-	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -22,96 +22,85 @@ const (
 	secretClientSecret = "instance-admin-client-secret"
 )
 
-func NewCmdCredentials(provider k8s.Provider) *cobra.Command {
+type CredentialsCmd struct {
+	Email    string `help:"Specify a new email address to use for authentication."`
+	Password string `help:"Specify a new password to use for authentication."`
+}
+
+func (cc *CredentialsCmd) Run(ctx context.Context, provider k8s.Provider) error {
 	spinner := &pterm.DefaultSpinner
 
-	var (
-		flagSetPassword string
-		flagSetEmail    string
-	)
+	return telClient.Wrap(ctx, telemetry.Credentials, func() error {
+		k8sClient, err := defaultK8s(provider.Kubeconfig, provider.Context)
+		if err != nil {
+			pterm.Error.Println("No existing cluster found")
+			return nil
+		}
 
-	cmd := &cobra.Command{
-		Use:   "credentials",
-		Short: "Get Airbyte user credentials",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return telClient.Wrap(cmd.Context(), telemetry.Credentials, func() error {
-				k8sClient, err := defaultK8s(provider.Kubeconfig, provider.Context)
-				if err != nil {
-					pterm.Error.Println("No existing cluster found")
-					return nil
-				}
+		secret, err := k8sClient.SecretGet(ctx, airbyteNamespace, airbyteAuthSecretName)
+		if err != nil {
+			return err
+		}
 
-				secret, err := k8sClient.SecretGet(cmd.Context(), airbyteNamespace, airbyteAuthSecretName)
-				if err != nil {
-					return err
-				}
+		clientId := string(secret.Data[secretClientID])
+		clientSecret := string(secret.Data[secretClientSecret])
 
-				clientId := string(secret.Data[secretClientID])
-				clientSecret := string(secret.Data[secretClientSecret])
+		port, err := getPort(ctx, provider)
+		if err != nil {
+			return err
+		}
 
-				port, err := getPort(cmd.Context(), provider)
-				if err != nil {
-					return err
-				}
+		abAPI := airbyte.New(fmt.Sprintf("http://localhost:%d", port), clientId, clientSecret)
 
-				abAPI := airbyte.New(fmt.Sprintf("http://localhost:%d", port), clientId, clientSecret)
+		if cc.Email != "" {
+			pterm.Info.Println("Updating email for authentication")
+			if err := abAPI.SetOrgEmail(ctx, cc.Email); err != nil {
+				pterm.Error.Println("Unable to update the email address")
+				return fmt.Errorf("unable to udpate the email address: %w", err)
+			}
+			pterm.Success.Println("Email updated")
+		}
 
-				if flagSetEmail != "" {
-					pterm.Info.Println("Updating email for authentication")
-					if err := abAPI.SetOrgEmail(cmd.Context(), flagSetEmail); err != nil {
-						pterm.Error.Println("Unable to update the email address")
-						return fmt.Errorf("unable to udpate the email address: %w", err)
-					}
-					pterm.Success.Println("Email updated")
-				}
+		if cc.Password != "" && cc.Password != string(secret.Data[secretPassword]) {
+			pterm.Info.Println("Updating password for authentication")
+			secret.Data[secretPassword] = []byte(cc.Password)
+			if err := k8sClient.SecretCreateOrUpdate(ctx, *secret); err != nil {
+				pterm.Error.Println("Unable to update the password")
+				return fmt.Errorf("unable to update the password: %w", err)
+			}
+			pterm.Success.Println("Password updated")
 
-				if flagSetPassword != "" && flagSetPassword != string(secret.Data[secretPassword]) {
-					pterm.Info.Println("Updating password for authentication")
-					secret.Data[secretPassword] = []byte(flagSetPassword)
-					if err := k8sClient.SecretCreateOrUpdate(cmd.Context(), *secret); err != nil {
-						pterm.Error.Println("Unable to update the password")
-						return fmt.Errorf("unable to update the password: %w", err)
-					}
-					pterm.Success.Println("Password updated")
+			// as the secret was updated, fetch it again
+			secret, err = k8sClient.SecretGet(ctx, airbyteNamespace, airbyteAuthSecretName)
+			if err != nil {
+				return err
+			}
 
-					// as the secret was updated, fetch it again
-					secret, err = k8sClient.SecretGet(cmd.Context(), airbyteNamespace, airbyteAuthSecretName)
-					if err != nil {
-						return err
-					}
+			spinner, _ = spinner.Start("Restarting airbyte-abctl-server")
+			if err := k8sClient.DeploymentRestart(ctx, airbyteNamespace, "airbyte-abctl-server"); err != nil {
+				pterm.Error.Println("Unable to restart airbyte-abctl-server")
+				return fmt.Errorf("unable to restart airbyte-abctl-server: %w", err)
+			}
+			spinner.Success("Restarted airbyte-abctl-server")
+		}
 
-					spinner, _ = spinner.Start("Restarting airbyte-abctl-server")
-					if err := k8sClient.DeploymentRestart(cmd.Context(), airbyteNamespace, "airbyte-abctl-server"); err != nil {
-						pterm.Error.Println("Unable to restart airbyte-abctl-server")
-						return fmt.Errorf("unable to restart airbyte-abctl-server: %w", err)
-					}
-					spinner.Success("Restarted airbyte-abctl-server")
-				}
+		orgEmail, err := abAPI.GetOrgEmail(ctx)
+		if err != nil {
+			pterm.Error.Println("Unable to determine organization email")
+			return fmt.Errorf("unable to determine organization email: %w", err)
+		}
+		if orgEmail == "" {
+			orgEmail = "[not set]"
+		}
 
-				orgEmail, err := abAPI.GetOrgEmail(cmd.Context())
-				if err != nil {
-					pterm.Error.Println("Unable to determine organization email")
-					return fmt.Errorf("unable to determine organization email: %w", err)
-				}
-				if orgEmail == "" {
-					orgEmail = "[not set]"
-				}
-
-				pterm.Success.Println(fmt.Sprintf("Retreiving your credentials from '%s'", secret.Name))
-				pterm.Info.Println(fmt.Sprintf(`Credentials:
+		pterm.Success.Println(fmt.Sprintf("Retreiving your credentials from '%s'", secret.Name))
+		pterm.Info.Println(fmt.Sprintf(`Credentials:
   Email: %s
   Password: %s
   Client-Id: %s
   Client-Secret: %s`, orgEmail, secret.Data[secretPassword], clientId, clientSecret))
-				return nil
-			})
-		},
-	}
-
-	cmd.Flags().StringVar(&flagSetEmail, "email", "", "specify the new email address for authentication")
-	cmd.Flags().StringVar(&flagSetPassword, "password", "", "specify the new password for authentication")
-
-	return cmd
+		return nil
+	})
 }
 
 func defaultK8s(kubecfg, kubectx string) (k8s.Client, error) {

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -1,233 +1,154 @@
 package local
 
 import (
+	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/airbytehq/abctl/internal/cmd/local/docker"
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
-	"github.com/airbytehq/abctl/internal/cmd/local/k8s/kind"
 	"github.com/airbytehq/abctl/internal/cmd/local/local"
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/pterm/pterm"
-	"github.com/spf13/cobra"
 )
 
-const (
-	// envBasicAuthUser is the env-var that can be specified to override the default basic-auth username.
-	envBasicAuthUser = "ABCTL_LOCAL_INSTALL_USERNAME"
-	// envBasicAuthPass is the env-var that can be specified to override the default basic-auth password.
-	envBasicAuthPass = "ABCTL_LOCAL_INSTALL_PASSWORD"
-
-	// envDockerServer is the env-var that can be specified to override the default docker registry.
-	envDockerServer = "ABCTL_LOCAL_INSTALL_DOCKER_SERVER"
-	// envDockerUser is the env-var that can be specified to override the default docker username.
-	envDockerUser = "ABCTL_LOCAL_INSTALL_DOCKER_USERNAME"
-	// envDockerPass is the env-var that can be specified to override the default docker password.
-	envDockerPass = "ABCTL_LOCAL_INSTALL_DOCKER_PASSWORD"
-	// envDockerEmail is the env-var that can be specified to override the default docker email.
-	envDockerEmail = "ABCTL_LOCAL_INSTALL_DOCKER_EMAIL"
-)
-
-type VolumeMount struct {
-	Path     string
-	HostPath string
+type InstallCmd struct {
+	ChartVersion    string   `default:"latest" help:"Version to install."`
+	DockerEmail     string   `group:"docker" help:"Docker email." env:"ABCTL_LOCAL_INSTALL_DOCKER_EMAIL"`
+	DockerPassword  string   `group:"docker" help:"Docker password." env:"ABCTL_LOCAL_INSTALL_DOCKER_PASSWORD"`
+	DockerServer    string   `group:"docker" default:"https://index.docker.io/v1/" help:"Docker server." env:"ABCTL_LOCAL_INSTALL_DOCKER_SERVER"`
+	DockerUsername  string   `group:"docker" help:"Docker username." env:"ABCTL_LOCAL_INSTALL_DOCKER_USERNAME"`
+	Host            string   `default:"localhost" help:"HTTP ingress host."`
+	InsecureCookies bool     `help:"Allow cookies to be served over HTTP."`
+	LowResourceMode bool     `help:"Run Airbyte in low resource mode."`
+	Migrate         bool     `help:"Migrate data from a previous Docker Compose Airbyte installation."`
+	NoBrowser       bool     `help:"Disable launching a browser post install."`
+	Port            int      `default:"8000" help:"HTTP ingress port."`
+	Secret          []string `type:"existingfile" help:"An Airbyte helm chart secret file."`
+	Values          string   `type:"existingfile" help:"An Airbyte helm chart values file to configure helm."`
+	Volume          []string `help:"Additional volume mounts. Must be in the format <HOST_PATH>:<GUEST_PATH>."`
 }
 
-func NewCmdInstall(provider k8s.Provider) *cobra.Command {
+func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider) error {
 	spinner := &pterm.DefaultSpinner
+	spinner, _ = spinner.Start("Starting installation")
+	spinner.UpdateText("Checking for Docker installation")
 
-	var (
-		flagChartValuesFile   string
-		flagChartSecrets      []string
-		flagChartVersion      string
-		flagMigrate           bool
-		flagPort              int
-		flagHost              string
-		flagExtraVolumeMounts []string
+	dockerVersion, err := dockerInstalled(ctx)
+	if err != nil {
+		pterm.Error.Println("Unable to determine if Docker is installed")
+		return fmt.Errorf("unable to determine docker installation status: %w", err)
+	}
 
-		flagDockerServer string
-		flagDockerUser   string
-		flagDockerPass   string
-		flagDockerEmail  string
+	telClient.Attr("docker_version", dockerVersion.Version)
+	telClient.Attr("docker_arch", dockerVersion.Arch)
+	telClient.Attr("docker_platform", dockerVersion.Platform)
 
-		flagNoBrowser       bool
-		flagLowResourceMode bool
-		flagInsecureCookies bool
-	)
+	spinner.UpdateText(fmt.Sprintf("Checking if port %d is available", i.Port))
+	if err := portAvailable(ctx, i.Port); err != nil {
+		return fmt.Errorf("port %d is not available: %w", i.Port, err)
+	}
 
-	cmd := &cobra.Command{
-		Use:   "install",
-		Short: "Install Airbyte locally",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			spinner, _ = spinner.Start("Starting installation")
-			spinner.UpdateText("Checking for Docker installation")
+	return telClient.Wrap(ctx, telemetry.Install, func() error {
+		spinner.UpdateText(fmt.Sprintf("Checking for existing Kubernetes cluster '%s'", provider.ClusterName))
 
-			dockerVersion, err := dockerInstalled(cmd.Context())
-			if err != nil {
-				pterm.Error.Println("Unable to determine if Docker is installed")
-				return fmt.Errorf("unable to determine docker installation status: %w", err)
-			}
+		cluster, err := provider.Cluster()
+		if err != nil {
+			pterm.Error.Printfln("Unable to determine status of any existing '%s' cluster", provider.ClusterName)
+			return err
+		}
 
-			telClient.Attr("docker_version", dockerVersion.Version)
-			telClient.Attr("docker_arch", dockerVersion.Arch)
-			telClient.Attr("docker_platform", dockerVersion.Platform)
+		if cluster.Exists() {
+			// existing cluster, validate it
+			pterm.Success.Printfln("Existing cluster '%s' found", provider.ClusterName)
+			spinner.UpdateText(fmt.Sprintf("Validating existing cluster '%s'", provider.ClusterName))
 
-			spinner.UpdateText(fmt.Sprintf("Checking if port %d is available", flagPort))
-			if err := portAvailable(cmd.Context(), flagPort); err != nil {
-				return fmt.Errorf("port %d is not available: %w", flagPort, err)
-			}
-			return nil
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return telClient.Wrap(cmd.Context(), telemetry.Install, func() error {
-				spinner.UpdateText(fmt.Sprintf("Checking for existing Kubernetes cluster '%s'", provider.ClusterName))
-
-				cluster, err := provider.Cluster()
-				if err != nil {
-					pterm.Error.Printfln("Unable to determine status of any existing '%s' cluster", provider.ClusterName)
-					return err
-				}
-
-				if cluster.Exists() {
-					// existing cluster, validate it
-					pterm.Success.Printfln("Existing cluster '%s' found", provider.ClusterName)
-					spinner.UpdateText(fmt.Sprintf("Validating existing cluster '%s'", provider.ClusterName))
-
-					// only for kind do we need to check the existing port
-					if provider.Name == k8s.Kind {
-						if dockerClient == nil {
-							dockerClient, err = docker.New(cmd.Context())
-							if err != nil {
-								pterm.Error.Printfln("Unable to connect to Docker daemon")
-								return fmt.Errorf("unable to connect to docker: %w", err)
-							}
-						}
-
-						providedPort := flagPort
-						flagPort, err = dockerClient.Port(cmd.Context(), fmt.Sprintf("%s-control-plane", provider.ClusterName))
-						if err != nil {
-							pterm.Warning.Printfln("Unable to determine which port the existing cluster was configured to use.\n" +
-								"Installation will continue but may ultimately fail, in which case it will be necessarily to uninstall first.")
-							// since we can't verify the port is correct, push forward with the provided port
-							flagPort = providedPort
-						}
-						if providedPort != flagPort {
-							pterm.Warning.Printfln("The existing cluster was found to be using port %d, which differs from the provided port %d.\n"+
-								"The existing port will be used, as changing ports currently requires the existing installation to be uninstalled first.", flagPort, providedPort)
-						}
-					}
-
-					pterm.Success.Printfln("Cluster '%s' validation complete", provider.ClusterName)
-				} else {
-					// no existing cluster, need to create one
-					pterm.Info.Println(fmt.Sprintf("No existing cluster found, cluster '%s' will be created", provider.ClusterName))
-					spinner.UpdateText(fmt.Sprintf("Creating cluster '%s'", provider.ClusterName))
-
-					extraVolumeMounts, err := parseVolumeMounts(flagExtraVolumeMounts)
+			// only for kind do we need to check the existing port
+			if provider.Name == k8s.Kind {
+				if dockerClient == nil {
+					dockerClient, err = docker.New(ctx)
 					if err != nil {
-						return err
+						pterm.Error.Printfln("Unable to connect to Docker daemon")
+						return fmt.Errorf("unable to connect to docker: %w", err)
 					}
-
-					if err := cluster.Create(flagPort, extraVolumeMounts); err != nil {
-						pterm.Error.Printfln("Cluster '%s' could not be created", provider.ClusterName)
-						return err
-					}
-					pterm.Success.Printfln("Cluster '%s' created", provider.ClusterName)
 				}
 
-				lc, err := local.New(provider,
-					local.WithPortHTTP(flagPort),
-					local.WithTelemetryClient(telClient),
-					local.WithSpinner(spinner),
-				)
+				providedPort := i.Port
+				i.Port, err = dockerClient.Port(ctx, fmt.Sprintf("%s-control-plane", provider.ClusterName))
 				if err != nil {
-					pterm.Error.Printfln("Failed to initialize 'local' command")
-					return fmt.Errorf("unable to initialize local command: %w", err)
+					pterm.Warning.Printfln("Unable to determine which port the existing cluster was configured to use.\n" +
+						"Installation will continue but may ultimately fail, in which case it will be necessarily to uninstall first.")
+					// since we can't verify the port is correct, push forward with the provided port
+					i.Port = providedPort
 				}
-
-				opts := local.InstallOpts{
-					HelmChartVersion: flagChartVersion,
-					ValuesFile:       flagChartValuesFile,
-					Secrets:          flagChartSecrets,
-					Migrate:          flagMigrate,
-					Docker:           dockerClient,
-					Host:             flagHost,
-
-					DockerServer: flagDockerServer,
-					DockerUser:   flagDockerUser,
-					DockerPass:   flagDockerPass,
-					DockerEmail:  flagDockerEmail,
-
-					NoBrowser:       flagNoBrowser,
-					LowResourceMode: flagLowResourceMode,
-					InsecureCookies: flagInsecureCookies,
+				if providedPort != i.Port {
+					pterm.Warning.Printfln("The existing cluster was found to be using port %d, which differs from the provided port %d.\n"+
+						"The existing port will be used, as changing ports currently requires the existing installation to be uninstalled first.", i.Port, providedPort)
 				}
+			}
 
-				if opts.HelmChartVersion == "latest" {
-					opts.HelmChartVersion = ""
-				}
+			pterm.Success.Printfln("Cluster '%s' validation complete", provider.ClusterName)
+		} else {
+			// no existing cluster, need to create one
+			pterm.Info.Println(fmt.Sprintf("No existing cluster found, cluster '%s' will be created", provider.ClusterName))
+			spinner.UpdateText(fmt.Sprintf("Creating cluster '%s'", provider.ClusterName))
 
-				envOverride(&opts.DockerServer, envDockerServer)
-				envOverride(&opts.DockerUser, envDockerUser)
-				envOverride(&opts.DockerPass, envDockerPass)
-				envOverride(&opts.DockerEmail, envDockerEmail)
+			extraVolumeMounts, err := parseVolumeMounts(i.Volume)
+			if err != nil {
+				return err
+			}
 
-				if err := lc.Install(cmd.Context(), opts); err != nil {
-					spinner.Fail("Unable to install Airbyte locally")
-					return err
-				}
+			if err := cluster.Create(i.Port, extraVolumeMounts); err != nil {
+				pterm.Error.Printfln("Cluster '%s' could not be created", provider.ClusterName)
+				return err
+			}
+			pterm.Success.Printfln("Cluster '%s' created", provider.ClusterName)
+		}
 
-				spinner.Success(
-					"Airbyte installation complete.\n" +
-						"  A password may be required to login. The password can by found by running\n" +
-						"  the command " + pterm.LightBlue("abctl local credentials"),
-				)
-				return nil
-			})
-		},
-	}
+		lc, err := local.New(provider,
+			local.WithPortHTTP(i.Port),
+			local.WithTelemetryClient(telClient),
+			local.WithSpinner(spinner),
+		)
+		if err != nil {
+			pterm.Error.Printfln("Failed to initialize 'local' command")
+			return fmt.Errorf("unable to initialize local command: %w", err)
+		}
 
-	cmd.FParseErrWhitelist.UnknownFlags = true
+		opts := local.InstallOpts{
+			HelmChartVersion: i.ChartVersion,
+			ValuesFile:       i.Values,
+			Secrets:          i.Secret,
+			Migrate:          i.Migrate,
+			Docker:           dockerClient,
+			Host:             i.Host,
 
-	// The username and password flags are deprecated, but must still be defined so we can check
-	// if they were set in order to issue the deprecated warning.
-	cmd.Flags().StringP("username", "u", "airbyte", "basic auth username, can also be specified via "+envBasicAuthUser)
-	cmd.Flags().StringP("password", "p", "password", "basic auth password, can also be specified via "+envBasicAuthPass)
-	_ = cmd.Flags().MarkHidden("username")
-	_ = cmd.Flags().MarkHidden("password")
+			DockerServer: i.DockerServer,
+			DockerUser:   i.DockerUsername,
+			DockerPass:   i.DockerPassword,
+			DockerEmail:  i.DockerEmail,
 
-	cmd.Flags().IntVar(&flagPort, "port", kind.IngressPort, "ingress http port")
-	cmd.Flags().StringVar(&flagHost, "host", "localhost", "ingress http host")
+			NoBrowser:       i.NoBrowser,
+			LowResourceMode: i.LowResourceMode,
+			InsecureCookies: i.InsecureCookies,
+		}
 
-	cmd.Flags().StringVar(&flagChartVersion, "chart-version", "latest", "specify the Airbyte helm chart version to install")
-	cmd.Flags().StringVar(&flagChartValuesFile, "values", "", "the Airbyte helm chart values file to load")
-	cmd.Flags().StringSliceVar(&flagChartSecrets, "secret", []string{}, "an Airbyte helm chart secret file")
-	cmd.Flags().StringSliceVar(&flagExtraVolumeMounts, "volume", []string{}, "additional volume mounts (format: <HOST_PATH>:<GUEST_PATH>)")
-	cmd.Flags().BoolVar(&flagMigrate, "migrate", false, "migrate data from docker compose installation")
+		if opts.HelmChartVersion == "latest" {
+			opts.HelmChartVersion = ""
+		}
 
-	cmd.Flags().StringVar(&flagDockerServer, "docker-server", "https://index.docker.io/v1/", "docker registry, can also be specified via "+envDockerServer)
-	cmd.Flags().StringVar(&flagDockerUser, "docker-username", "", "docker username, can also be specified via "+envDockerEmail)
-	cmd.Flags().StringVar(&flagDockerPass, "docker-password", "", "docker password, can also be specified via "+envDockerPass)
-	cmd.Flags().StringVar(&flagDockerEmail, "docker-email", "", "docker email, can also be specified via "+envDockerEmail)
+		if err := lc.Install(ctx, opts); err != nil {
+			spinner.Fail("Unable to install Airbyte locally")
+			return err
+		}
 
-	cmd.Flags().BoolVar(&flagNoBrowser, "no-browser", false, "disable launching the web-browser post install")
-	cmd.Flags().BoolVar(&flagLowResourceMode, "low-resource-mode", false, "run Airbyte in low resource mode")
-	cmd.Flags().BoolVar(&flagInsecureCookies, "insecure-cookies", false, "allow insecure cookies to be served over http")
-
-	cmd.MarkFlagsRequiredTogether("docker-username", "docker-password", "docker-email")
-
-	return cmd
-}
-
-// envOverride checks if the env exists and is not empty, if that is true
-// update the original value to be the value returned from the env environment variable.
-// Otherwise, leave the original value alone.
-func envOverride(original *string, env string) {
-	if v := os.Getenv(env); v != "" {
-		*original = v
-	}
+		spinner.Success(
+			"Airbyte installation complete.\n" +
+				"  A password may be required to login. The password can by found by running\n" +
+				"  the command " + pterm.LightBlue("abctl local credentials"),
+		)
+		return nil
+	})
 }
 
 func parseVolumeMounts(specs []string) ([]k8s.ExtraVolumeMount, error) {

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -29,7 +29,7 @@ type InstallCmd struct {
 	Volume          []string `help:"Additional volume mounts. Must be in the format <HOST_PATH>:<GUEST_PATH>."`
 }
 
-func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider) error {
+func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient telemetry.Client) error {
 	spinner := &pterm.DefaultSpinner
 	spinner, _ = spinner.Start("Starting installation")
 	spinner.UpdateText("Checking for Docker installation")

--- a/internal/cmd/local/local_status.go
+++ b/internal/cmd/local/local_status.go
@@ -1,82 +1,83 @@
 package local
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
 	"github.com/airbytehq/abctl/internal/cmd/local/local"
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/pterm/pterm"
-	"github.com/spf13/cobra"
 )
 
-func NewCmdStatus(provider k8s.Provider) *cobra.Command {
+type StatusCmd struct{}
+
+func (s *StatusCmd) Run(ctx context.Context, provider k8s.Provider) error {
 	spinner := &pterm.DefaultSpinner
-
-	cmd := &cobra.Command{
-		Use:   "status",
-		Short: "Status of local Airbyte",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			spinner, _ = spinner.Start("Starting status check")
-			spinner.UpdateText("Checking for Docker installation")
-
-			dockerVersion, err := dockerInstalled(cmd.Context())
-			if err != nil {
-				pterm.Error.Println("Unable to determine if Docker is installed")
-				return fmt.Errorf("unable to determine docker installation status: %w", err)
-			}
-
-			telClient.Attr("docker_version", dockerVersion.Version)
-			telClient.Attr("docker_arch", dockerVersion.Arch)
-			telClient.Attr("docker_platform", dockerVersion.Platform)
-
-			return nil
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return telClient.Wrap(cmd.Context(), telemetry.Status, func() error {
-				spinner.UpdateText(fmt.Sprintf("Checking for existing Kubernetes cluster '%s'", provider.ClusterName))
-
-				cluster, err := provider.Cluster()
-				if err != nil {
-					pterm.Error.Printfln("Unable to determine status of any existing '%s' cluster", provider.ClusterName)
-					return err
-				}
-
-				if !cluster.Exists() {
-					pterm.Warning.Println("Airbyte does not appear to be installed locally")
-					return nil
-				}
-
-				pterm.Success.Printfln("Existing cluster '%s' found", provider.ClusterName)
-				spinner.UpdateText(fmt.Sprintf("Validating existing cluster '%s'", provider.ClusterName))
-
-				port, err := getPort(cmd.Context(), provider)
-				if err != nil {
-					return err
-				}
-
-				lc, err := local.New(provider,
-					local.WithPortHTTP(port),
-					local.WithTelemetryClient(telClient),
-					local.WithSpinner(spinner),
-				)
-				if err != nil {
-					pterm.Error.Printfln("Failed to initialize 'local' command")
-					return fmt.Errorf("unable to initialize local command: %w", err)
-				}
-
-				if err := lc.Status(cmd.Context()); err != nil {
-					spinner.Fail("Unable to install Airbyte locally")
-					return err
-				}
-
-				spinner.Success("Status check")
-				return nil
-			})
-		},
+	if err := checkDocker(ctx, spinner); err != nil {
+		return err
 	}
 
-	cmd.FParseErrWhitelist.UnknownFlags = true
+	return telClient.Wrap(ctx, telemetry.Status, func() error {
+		return status(ctx, provider, spinner)
+	})
+}
 
-	return cmd
+func checkDocker(ctx context.Context, spinner *pterm.SpinnerPrinter) error {
+	spinner, _ = spinner.Start("Starting status check")
+	spinner.UpdateText("Checking for Docker installation")
+
+	dockerVersion, err := dockerInstalled(ctx)
+	if err != nil {
+		pterm.Error.Println("Unable to determine if Docker is installed")
+		return fmt.Errorf("unable to determine docker installation status: %w", err)
+	}
+
+	telClient.Attr("docker_version", dockerVersion.Version)
+	telClient.Attr("docker_arch", dockerVersion.Arch)
+	telClient.Attr("docker_platform", dockerVersion.Platform)
+
+	return nil
+}
+
+func status(ctx context.Context, provider k8s.Provider, spinner *pterm.SpinnerPrinter) error {
+	spinner.UpdateText(fmt.Sprintf("Checking for existing Kubernetes cluster '%s'", provider.ClusterName))
+
+	cluster, err := provider.Cluster()
+	if err != nil {
+		pterm.Error.Printfln("Unable to determine status of any existing '%s' cluster", provider.ClusterName)
+		return err
+	}
+
+	if !cluster.Exists() {
+		pterm.Warning.Println("Airbyte does not appear to be installed locally")
+		return nil
+	}
+
+	pterm.Success.Printfln("Existing cluster '%s' found", provider.ClusterName)
+	spinner.UpdateText(fmt.Sprintf("Validating existing cluster '%s'", provider.ClusterName))
+
+	port, err := getPort(ctx, provider)
+	if err != nil {
+		return err
+	}
+
+	lc, err := local.New(provider,
+		local.WithPortHTTP(port),
+		local.WithTelemetryClient(telClient),
+		local.WithSpinner(spinner),
+	)
+	if err != nil {
+		pterm.Error.Printfln("Failed to initialize 'local' command")
+		return fmt.Errorf("unable to initialize local command: %w", err)
+	}
+
+	if err := lc.Status(ctx); err != nil {
+		spinner.Fail("Unable to install Airbyte locally")
+		return err
+	}
+
+	_ = spinner.Stop()
+
+	return nil
 }

--- a/internal/cmd/local/local_status.go
+++ b/internal/cmd/local/local_status.go
@@ -12,18 +12,18 @@ import (
 
 type StatusCmd struct{}
 
-func (s *StatusCmd) Run(ctx context.Context, provider k8s.Provider) error {
+func (s *StatusCmd) Run(ctx context.Context, provider k8s.Provider, telClient telemetry.Client) error {
 	spinner := &pterm.DefaultSpinner
-	if err := checkDocker(ctx, spinner); err != nil {
+	if err := checkDocker(ctx, telClient, spinner); err != nil {
 		return err
 	}
 
 	return telClient.Wrap(ctx, telemetry.Status, func() error {
-		return status(ctx, provider, spinner)
+		return status(ctx, provider, telClient, spinner)
 	})
 }
 
-func checkDocker(ctx context.Context, spinner *pterm.SpinnerPrinter) error {
+func checkDocker(ctx context.Context, telClient telemetry.Client, spinner *pterm.SpinnerPrinter) error {
 	spinner, _ = spinner.Start("Starting status check")
 	spinner.UpdateText("Checking for Docker installation")
 
@@ -40,7 +40,7 @@ func checkDocker(ctx context.Context, spinner *pterm.SpinnerPrinter) error {
 	return nil
 }
 
-func status(ctx context.Context, provider k8s.Provider, spinner *pterm.SpinnerPrinter) error {
+func status(ctx context.Context, provider k8s.Provider, telClient telemetry.Client, spinner *pterm.SpinnerPrinter) error {
 	spinner.UpdateText(fmt.Sprintf("Checking for existing Kubernetes cluster '%s'", provider.ClusterName))
 
 	cluster, err := provider.Cluster()

--- a/internal/cmd/local/local_uninstall.go
+++ b/internal/cmd/local/local_uninstall.go
@@ -1,84 +1,72 @@
 package local
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
 	"github.com/airbytehq/abctl/internal/cmd/local/local"
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/pterm/pterm"
-	"github.com/spf13/cobra"
 )
 
-func NewCmdUninstall(provider k8s.Provider) *cobra.Command {
+type UninstallCmd struct {
+	Persisted bool `help:"Remove persisted data."`
+}
+
+func (u *UninstallCmd) Run(ctx context.Context, provider k8s.Provider) error {
 	spinner := &pterm.DefaultSpinner
 
-	var flagPersisted bool
+	spinner, _ = spinner.Start("Starting uninstallation")
+	spinner.UpdateText("Checking for Docker installation")
 
-	cmd := &cobra.Command{
-		Use:   "uninstall",
-		Short: "Uninstall Airbyte locally",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			spinner, _ = spinner.Start("Starting uninstallation")
-			spinner.UpdateText("Checking for Docker installation")
-
-			dockerVersion, err := dockerInstalled(cmd.Context())
-			if err != nil {
-				pterm.Error.Println("Unable to determine if Docker is installed")
-				return fmt.Errorf("unable to determine docker installation status: %w", err)
-			}
-
-			telClient.Attr("docker_version", dockerVersion.Version)
-			telClient.Attr("docker_arch", dockerVersion.Arch)
-			telClient.Attr("docker_platform", dockerVersion.Platform)
-
-			return nil
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return telClient.Wrap(cmd.Context(), telemetry.Uninstall, func() error {
-				spinner.UpdateText(fmt.Sprintf("Checking for existing Kubernetes cluster '%s'", provider.ClusterName))
-
-				cluster, err := provider.Cluster()
-				if err != nil {
-					pterm.Error.Printfln("Unable to determine if the cluster '%s' exists", provider.ClusterName)
-					return err
-				}
-
-				// if no cluster exists, there is nothing to do
-				if !cluster.Exists() {
-					pterm.Success.Printfln("Cluster '%s' does not exist\nNo additional action required", provider.ClusterName)
-					return nil
-				}
-
-				pterm.Success.Printfln("Existing cluster '%s' found", provider.ClusterName)
-
-				lc, err := local.New(provider, local.WithTelemetryClient(telClient), local.WithSpinner(spinner))
-				if err != nil {
-					pterm.Warning.Printfln("Failed to initialize 'local' command\nUninstallation attempt will continue")
-					pterm.Debug.Printfln("Initialization of 'local' failed with %s", err.Error())
-				} else {
-					if err := lc.Uninstall(cmd.Context(), local.UninstallOpts{Persisted: flagPersisted}); err != nil {
-						pterm.Warning.Printfln("unable to complete uninstall: %s", err.Error())
-						pterm.Warning.Println("will still attempt to uninstall the cluster")
-					}
-				}
-
-				spinner.UpdateText(fmt.Sprintf("Verifying uninstallation status of cluster '%s'", provider.ClusterName))
-				if err := cluster.Delete(); err != nil {
-					pterm.Error.Printfln(fmt.Sprintf("Uninstallation of cluster '%s' failed", provider.ClusterName))
-					return fmt.Errorf("unable to uninstall cluster %s", provider.ClusterName)
-				}
-				pterm.Success.Printfln(fmt.Sprintf("Uninstallation of cluster '%s' completed successfully", provider.ClusterName))
-
-				spinner.Success("Airbyte uninstallation complete")
-
-				return nil
-			})
-		},
+	dockerVersion, err := dockerInstalled(ctx)
+	if err != nil {
+		pterm.Error.Println("Unable to determine if Docker is installed")
+		return fmt.Errorf("unable to determine docker installation status: %w", err)
 	}
 
-	cmd.FParseErrWhitelist.UnknownFlags = true
-	cmd.Flags().BoolVar(&flagPersisted, "persisted", false, "remove persisted data")
+	telClient.Attr("docker_version", dockerVersion.Version)
+	telClient.Attr("docker_arch", dockerVersion.Arch)
+	telClient.Attr("docker_platform", dockerVersion.Platform)
 
-	return cmd
+	return telClient.Wrap(ctx, telemetry.Uninstall, func() error {
+		spinner.UpdateText(fmt.Sprintf("Checking for existing Kubernetes cluster '%s'", provider.ClusterName))
+
+		cluster, err := provider.Cluster()
+		if err != nil {
+			pterm.Error.Printfln("Unable to determine if the cluster '%s' exists", provider.ClusterName)
+			return err
+		}
+
+		// if no cluster exists, there is nothing to do
+		if !cluster.Exists() {
+			pterm.Success.Printfln("Cluster '%s' does not exist\nNo additional action required", provider.ClusterName)
+			return nil
+		}
+
+		pterm.Success.Printfln("Existing cluster '%s' found", provider.ClusterName)
+
+		lc, err := local.New(provider, local.WithTelemetryClient(telClient), local.WithSpinner(spinner))
+		if err != nil {
+			pterm.Warning.Printfln("Failed to initialize 'local' command\nUninstallation attempt will continue")
+			pterm.Debug.Printfln("Initialization of 'local' failed with %s", err.Error())
+		} else {
+			if err := lc.Uninstall(ctx, local.UninstallOpts{Persisted: u.Persisted}); err != nil {
+				pterm.Warning.Printfln("unable to complete uninstall: %s", err.Error())
+				pterm.Warning.Println("will still attempt to uninstall the cluster")
+			}
+		}
+
+		spinner.UpdateText(fmt.Sprintf("Verifying uninstallation status of cluster '%s'", provider.ClusterName))
+		if err := cluster.Delete(); err != nil {
+			pterm.Error.Printfln(fmt.Sprintf("Uninstallation of cluster '%s' failed", provider.ClusterName))
+			return fmt.Errorf("unable to uninstall cluster %s", provider.ClusterName)
+		}
+		pterm.Success.Printfln(fmt.Sprintf("Uninstallation of cluster '%s' completed successfully", provider.ClusterName))
+
+		spinner.Success("Airbyte uninstallation complete")
+
+		return nil
+	})
 }

--- a/internal/cmd/local/local_uninstall.go
+++ b/internal/cmd/local/local_uninstall.go
@@ -14,7 +14,7 @@ type UninstallCmd struct {
 	Persisted bool `help:"Remove persisted data."`
 }
 
-func (u *UninstallCmd) Run(ctx context.Context, provider k8s.Provider) error {
+func (u *UninstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient telemetry.Client) error {
 	spinner := &pterm.DefaultSpinner
 
 	spinner, _ = spinner.Start("Starting uninstallation")

--- a/internal/cmd/version/version.go
+++ b/internal/cmd/version/version.go
@@ -6,27 +6,22 @@ import (
 
 	"github.com/airbytehq/abctl/internal/build"
 	"github.com/pterm/pterm"
-	"github.com/spf13/cobra"
 )
 
-// NewCmdVersion returns a cobra command for printing the version information.
-// The version information is read directly from build.Version.
-func NewCmdVersion() *cobra.Command {
-	return &cobra.Command{
-		Use:   "version",
-		Short: "Print version information",
-		Run: func(cmd *cobra.Command, args []string) {
-			parts := []string{fmt.Sprintf("version: %s", build.Version)}
-			if build.Revision != "" {
-				parts = append(parts, fmt.Sprintf("revision: %s", build.Revision))
-			}
-			if build.ModificationTime != "" {
-				parts = append(parts, fmt.Sprintf("time: %s", build.ModificationTime))
-			}
-			if build.Modified {
-				parts = append(parts, fmt.Sprintf("modified: %t", build.Modified))
-			}
-			pterm.Println(strings.Join(parts, "\n"))
-		},
+type Cmd struct{}
+
+func (c *Cmd) Run() error {
+	parts := []string{fmt.Sprintf("version: %s", build.Version)}
+	if build.Revision != "" {
+		parts = append(parts, fmt.Sprintf("revision: %s", build.Revision))
 	}
+	if build.ModificationTime != "" {
+		parts = append(parts, fmt.Sprintf("time: %s", build.ModificationTime))
+	}
+	if build.Modified {
+		parts = append(parts, fmt.Sprintf("modified: %t", build.Modified))
+	}
+	pterm.Println(strings.Join(parts, "\n"))
+
+	return nil
 }

--- a/internal/cmd/version/version_test.go
+++ b/internal/cmd/version/version_test.go
@@ -79,9 +79,9 @@ func TestCmd_Output(t *testing.T) {
 			build.ModificationTime = tt.modificationTime
 			build.Modified = tt.modified
 
-			cmd := NewCmdVersion()
+			cmd := Cmd{}
 
-			if err := cmd.Execute(); err != nil {
+			if err := cmd.Run(); err != nil {
 				t.Fatal(err)
 			}
 

--- a/main.go
+++ b/main.go
@@ -45,12 +45,10 @@ func main() {
 
 	var root cmd.Cmd
 	parser, err := kong.New(
-		//parsed := kong.Parse(
 		&root,
 		kong.Name("abctl"),
 		kong.Description("Airbyte's command line tool for managing a local Airbyte installation."),
 		kong.UsageOnError(),
-		//kong.ShortUsageOnError(),
 	)
 	if err != nil {
 		cmd.HandleErr(err)
@@ -64,9 +62,6 @@ func main() {
 	}
 
 	cmd.HandleErr(parsed.Run())
-	//cmd.HandleErr(parsed.Run())
-	//root := cmd.NewCmd()
-	//cmd.Execute(ctx, root)
 
 	newRelease := <-updateChan
 	if newRelease.err != nil {

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/airbytehq/abctl/internal/build"
 	"github.com/airbytehq/abctl/internal/cmd"
 	"github.com/airbytehq/abctl/internal/update"
+	"github.com/alecthomas/kong"
 	"github.com/pterm/pterm"
 )
 
@@ -42,17 +43,45 @@ func main() {
 	// ensure the pterm info width matches the other printers
 	pterm.Info.Prefix.Text = " INFO  "
 
-	root := cmd.NewCmd()
-	cmd.Execute(ctx, root)
+	var root cmd.Cmd
+	parser, err := kong.New(
+		//parsed := kong.Parse(
+		&root,
+		kong.Name("abctl"),
+		kong.Description("Airbyte's command line tool for managing a local Airbyte installation."),
+		kong.UsageOnError(),
+		//kong.ShortUsageOnError(),
+	)
+	if err != nil {
+		cmd.HandleErr(err)
+	}
+	parsed, err := parser.Parse(os.Args[1:])
+	if err != nil {
+		cmd.HandleErr(err)
+	}
+	if err := parsed.BindToProvider(bindCtx(ctx)); err != nil {
+		cmd.HandleErr(err)
+	}
+
+	cmd.HandleErr(parsed.Run())
+	//cmd.HandleErr(parsed.Run())
+	//root := cmd.NewCmd()
+	//cmd.Execute(ctx, root)
 
 	newRelease := <-updateChan
 	if newRelease.err != nil {
 		if errors.Is(newRelease.err, update.ErrDevVersion) {
-			pterm.DefaultLogger.Debug("Release checking is disabled for dev builds")
+			pterm.Debug.Println("Release checking is disabled for dev builds")
 		}
 	} else if newRelease.version != "" {
 		pterm.Println()
 		pterm.Info.Printfln("A new release of abctl is available: %s -> %s\nUpdating to the latest version is highly recommended", build.Version, newRelease.version)
+	}
+}
+
+func bindCtx(ctx context.Context) func() (context.Context, error) {
+	return func() (context.Context, error) {
+		return ctx, nil
 	}
 }
 


### PR DESCRIPTION
- replace [cobra](github.com/spf13/cobra) with [kong](https://github.com/alecthomas/kong)
    - kong's approach is cleaner and easier to test
        - cobra
           ```go
           func NewCmdCredentials(provider k8s.Provider) *cobra.Command {
             spinner := &pterm.DefaultSpinner

             var (
               flagSetPassword string
               flagSetEmail    string
             )

             cmd := &cobra.Command{
               Use:   "credentials",
               Short: "Get Airbyte user credentials",
               RunE: func(cmd *cobra.Command, args []string) error {
                 return telClient.Wrap(cmd.Context(), telemetry.Credentials, func() error {
                   // ...
                 })
               },
             }

             cmd.Flags().StringVar(&flagSetEmail, "email", "", "specify the new email address for authentication")
             cmd.Flags().StringVar(&flagSetPassword, "password", "", "specify the new password for authentication")

             return cmd
           }
           ```
        - kong
           ```go
           type Cmd struct {
             Credentials CredentialsCmd `cmd:"" help:"Get local Airbyte user credentials."`
           }
           
           type CredentialsCmd struct {
             Email    string `help:"Specify a new email address to use for authentication."`
             Password string `help:"Specify a new password to use for authentication."`
           }

           func (cc *CredentialsCmd) Run(ctx context.Context, provider k8s.Provider, telClient telemetry.Client) error {
             return telClient.Wrap(ctx, telemetry.Credentials, func() error {
               // ...
             })
           }
           ```