### PR TITLE
ci: add github workflow for releases

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.2'
+          go-version: 'stable'
 
       - name: Build
         run: make build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,5 +24,5 @@ jobs:
       - uses: ncipollo/release-action@v1
         with:
           generateReleaseNotes: true
-          artifacts: "build/release/*.tar.gz"
+          artifacts: "build/release/*.tar.gz,build/release/*.zip"
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Create Release
+
+jobs:
+  create-release:
+    name: Build and Publish Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get the version
+        id: get_version
+        run: echo "ABCTL_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+           go-version: 'stable'
+      - name: Make Release
+        run: make clean release
+      - name: Check version
+        run: ./build/release/abctl-$ABCTL_VERSION-linux-amd64/abctl version
+      - uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+          artifacts: "build/release/*.tar.gz"
+        


### PR DESCRIPTION
https://github.com/airbytehq/airbyte-internal-issues/issues/9451

This adds a github workflow for releases. The workflow is triggered when a tag is pushed with the `v...` prefix (e.g. `v1.2.3`). The workflow sets `ABCTL_VERSION` to the tag name, sets up Go, builds all the releases using the existing script, creates a release, and uploads the artifacts.

I've changed the Go version used to `stable`, which should always pull the latest stable version. If you'd prefer to stick with `1.22.2` and manually update both files on new Go releases, I can change it.

This currently takes about 5 minutes. It builds the versions serially instead of in parallel, because that was easiest. It's probably fast enough, but if we want it to be faster we can possibly parallelize the builds for different architectures.

This does not handle updating the Homebrew formula yet. I'll handle that next (https://github.com/airbytehq/airbyte-internal-issues/issues/9450). 

I've been testing this on a fork at https://github.com/abuchanan-airbyte/abctl/actions/workflows/hello_world.yml if you want to see the results or mess around.

There are some config options for the "create release" action that might need some tweaking: [docs](https://github.com/ncipollo/release-action?tab=readme-ov-file#action-inputs)
- artifactErrorsFailBuild should maybe be true (defaults to false)
- artifactContentType maybe there's something special here?

Updates to an existing release will fail. I doubt that will matter – we'd probably just delete the release and re-run the job, or create another tag.