### PR TITLE
ci: update homebrew tap on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
         run: git diff
       - name: Commit changes
         run: |
-          git config user.email "robot@airbyte.io"
-          git config user.name "abctl release action"
+          git config user.email ${{ secrets.PRODENG_BOT_EMAIL }}
+          git config user.name "airbyte-prodeng"
           git commit -a -m "chore: update abctl to $ABCTL_VERSION"
       - name: Push change
         run: git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,20 @@ jobs:
         with:
           generateReleaseNotes: true
           artifacts: "build/release/*.tar.gz,build/release/*.zip"
+      - uses: actions/checkout@v4
+        with:
+          repository: abuchanan-airbyte/homebrew-tap
+          ssh-key: ${{ secrets.ABCTL_HOMEBREW_KEY }}
+      - name: Replace version
+        run: |
+          sed -i 's/ABCTL_VERSION = ".*"/ABCTL_VERSION = "'$ABCTL_VERSION'"/' Formula/abctl.rb
+      - name: Show diff
+        run: git diff
+      - name: Commit changes
+        run: |
+          git config user.email "robot@airbyte.io"
+          git config user.name "abctl release action"
+          git commit -a -m "Update abctl to $ABCTL_VERSION"
+      - name: Push change
+        run: git push
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           artifacts: "build/release/*.tar.gz,build/release/*.zip"
       - uses: actions/checkout@v4
         with:
-          repository: abuchanan-airbyte/homebrew-tap
+          repository: airbytehq/homebrew-tap
           ssh-key: ${{ secrets.ABCTL_HOMEBREW_KEY }}
       - name: Replace version
         run: |
@@ -38,7 +38,7 @@ jobs:
         run: |
           git config user.email "robot@airbyte.io"
           git config user.name "abctl release action"
-          git commit -a -m "Update abctl to $ABCTL_VERSION"
+          git commit -a -m "chore: update abctl to $ABCTL_VERSION"
       - name: Push change
         run: git push
         


### PR DESCRIPTION
https://github.com/airbytehq/airbyte-internal-issues/issues/9450

This adds steps to the release workflow to checkout the homebrew tap, update the version, and push a commit to that repo.

This depends on having write access to the homebrew tap repo, which is granted via [Deploy Keys](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys)

I made up a robot user for the git name/email here. I'm not sure if we have an actual user/account that would be better.