### PR TITLE
feat: add the ability list and restart deployments

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -110,6 +110,8 @@ func (c *Cmd) BeforeApply(ctx *kong.Context) error {
 	return nil
 }
 
+// bindK8sClient allows kong to make the k8s.Client injectable into a command's Run method.
+// If the cluster does exist, this will return ErrClusterNotFound.
 func bindK8sClient(provider *k8s.Provider) func() (k8s.Client, error) {
 	return func() (k8s.Client, error) {
 		k8sCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/airbytehq/abctl/internal/cmd/local"
@@ -11,13 +12,19 @@ import (
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/alecthomas/kong"
 	"github.com/pterm/pterm"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Help messages to display for specific error situations.
 const (
-	// helpAirbyteDir is display if ErrAirbyteDir is ever returned
+	// helpAirbyteDir is displayed if ErrAirbyteDir is ever returned
 	helpAirbyteDir = `The ~/.airbyte directory is inaccessible.
 You may need to remove this directory before trying your command again.`
+
+	// helpCluster is displayed if ErrClusterNotFound is ever returned
+	helpCluster = `No cluster was found. If this is unexpected,
+you may need to run the "local install" command again.`
 
 	// helpDocker is displayed if ErrDocker is ever returned
 	helpDocker = `An error occurred while communicating with the Docker daemon.
@@ -56,6 +63,9 @@ func HandleErr(err error) {
 	case errors.Is(err, localerr.ErrAirbyteDir):
 		pterm.Println()
 		pterm.Info.Println(helpAirbyteDir)
+	case errors.Is(err, localerr.ErrClusterNotFound):
+		pterm.Println()
+		pterm.Info.Println(helpCluster)
 	case errors.Is(err, localerr.ErrDocker):
 		pterm.Println()
 		pterm.Info.Println(helpDocker)
@@ -92,6 +102,37 @@ func (c *Cmd) BeforeApply(ctx *kong.Context) error {
 	}
 	ctx.BindTo(k8s.DefaultProvider, (*k8s.Provider)(nil))
 	ctx.BindTo(telemetry.Get(), (*telemetry.Client)(nil))
+	if err := ctx.BindToProvider(bindK8sClient(&k8s.DefaultProvider)); err != nil {
+		pterm.Error.Println("Unable to configure k8s client")
+		return fmt.Errorf("unable to create k8s client: %w", err)
+	}
 
 	return nil
+}
+
+func bindK8sClient(provider *k8s.Provider) func() (k8s.Client, error) {
+	return func() (k8s.Client, error) {
+		k8sCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: provider.Kubeconfig},
+			&clientcmd.ConfigOverrides{CurrentContext: provider.Context},
+		)
+
+		if cluster, err := provider.Cluster(); err != nil {
+			pterm.Error.Println("Unable to determine cluster state")
+			return nil, fmt.Errorf("unable to determine cluster state: %w", err)
+		} else if !cluster.Exists() {
+			return nil, localerr.ErrClusterNotFound
+		}
+
+		restCfg, err := k8sCfg.ClientConfig()
+		if err != nil {
+			return nil, fmt.Errorf("%w: could not create rest config: %w", localerr.ErrKubernetes, err)
+		}
+		k8sClient, err := kubernetes.NewForConfig(restCfg)
+		if err != nil {
+			return nil, fmt.Errorf("%w: could not create clientset: %w", localerr.ErrKubernetes, err)
+		}
+
+		return &k8s.DefaultK8sClient{ClientSet: k8sClient}, nil
+	}
 }

--- a/internal/cmd/local/k8s/client.go
+++ b/internal/cmd/local/k8s/client.go
@@ -84,6 +84,10 @@ type DefaultK8sClient struct {
 	ClientSet kubernetes.Interface
 }
 
+func (d *DefaultK8sClient) DeploymentList(ctx context.Context, namespace string) (*v1.DeploymentList, error) {
+	return d.ClientSet.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+}
+
 func (d *DefaultK8sClient) DeploymentRestart(ctx context.Context, namespace, name string) error {
 	return d.deploymentRestart(ctx, namespace, name, time.Now(), 5*time.Minute)
 }
@@ -301,12 +305,7 @@ func (d *DefaultK8sClient) ServerVersionGet() (string, error) {
 }
 
 func (d *DefaultK8sClient) ServiceGet(ctx context.Context, namespace string, name string) (*corev1.Service, error) {
-	d.ClientSet.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{})
 	return d.ClientSet.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
-}
-
-func (d *DefaultK8sClient) DeploymentList(ctx context.Context, namespace string) (*v1.DeploymentList, error) {
-	return d.ClientSet.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
 }
 
 func (d *DefaultK8sClient) EventsWatch(ctx context.Context, namespace string) (watch.Interface, error) {

--- a/internal/cmd/local/k8s/client.go
+++ b/internal/cmd/local/k8s/client.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -26,9 +27,12 @@ var DefaultPersistentVolumeSize = resource.MustParse("500Mi")
 
 // Client primarily for testing purposes
 type Client interface {
+	// DeploymentList returns a list of all the services within the namespace
+	DeploymentList(ctx context.Context, namespace string) (*v1.DeploymentList, error)
 	// DeploymentRestart will force a restart of the deployment name in the provided namespace.
 	// This is a blocking call, it should only return once the deployment has completed.
 	DeploymentRestart(ctx context.Context, namespace, name string) error
+
 	// IngressCreate creates an ingress in the given namespace
 	IngressCreate(ctx context.Context, namespace string, ingress *networkingv1.Ingress) error
 	// IngressExists returns true if the ingress exists in the namespace, false otherwise.
@@ -59,6 +63,7 @@ type Client interface {
 
 	// SecretCreateOrUpdate will update or create the secret name with the payload of data in the specified namespace
 	SecretCreateOrUpdate(ctx context.Context, secret corev1.Secret) error
+	// SecretGet returns the services for the namespace and name
 	SecretGet(ctx context.Context, namespace, name string) (*corev1.Secret, error)
 
 	// ServiceGet returns the service for the given namespace and name
@@ -114,9 +119,7 @@ func (d *DefaultK8sClient) deploymentRestart(ctx context.Context, namespace, nam
 	label := metav1.FormatLabelSelector(deployment.Spec.Selector)
 
 	deploymentPods := func(ctx context.Context) (bool, error) {
-		pods, err := d.ClientSet.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
-			LabelSelector: label,
-		})
+		pods, err := d.ClientSet.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: label})
 		if err != nil {
 			return false, fmt.Errorf("unable to list pods for deployment %s: %w", name, err)
 		}
@@ -298,7 +301,12 @@ func (d *DefaultK8sClient) ServerVersionGet() (string, error) {
 }
 
 func (d *DefaultK8sClient) ServiceGet(ctx context.Context, namespace string, name string) (*corev1.Service, error) {
+	d.ClientSet.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{})
 	return d.ClientSet.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+func (d *DefaultK8sClient) DeploymentList(ctx context.Context, namespace string) (*v1.DeploymentList, error) {
+	return d.ClientSet.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
 }
 
 func (d *DefaultK8sClient) EventsWatch(ctx context.Context, namespace string) (watch.Interface, error) {

--- a/internal/cmd/local/k8s/k8stest/k8stest.go
+++ b/internal/cmd/local/k8s/k8stest/k8stest.go
@@ -1,0 +1,168 @@
+package k8stest
+
+import (
+	"context"
+
+	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+var _ k8s.Client = (*MockClient)(nil)
+
+type MockClient struct {
+	FnDeploymentList              func(ctx context.Context, namespace string) (*v1.DeploymentList, error)
+	FnDeploymentRestart           func(ctx context.Context, namespace, name string) error
+	FnIngressCreate               func(ctx context.Context, namespace string, ingress *networkingv1.Ingress) error
+	FnIngressExists               func(ctx context.Context, namespace string, ingress string) bool
+	FnIngressUpdate               func(ctx context.Context, namespace string, ingress *networkingv1.Ingress) error
+	FnNamespaceCreate             func(ctx context.Context, namespace string) error
+	FnNamespaceExists             func(ctx context.Context, namespace string) bool
+	FnNamespaceDelete             func(ctx context.Context, namespace string) error
+	FnPersistentVolumeCreate      func(ctx context.Context, namespace, name string) error
+	FnPersistentVolumeExists      func(ctx context.Context, namespace, name string) bool
+	FnPersistentVolumeDelete      func(ctx context.Context, namespace, name string) error
+	FnPersistentVolumeClaimCreate func(ctx context.Context, namespace, name, volumeName string) error
+	FnPersistentVolumeClaimExists func(ctx context.Context, namespace, name, volumeName string) bool
+	FnPersistentVolumeClaimDelete func(ctx context.Context, namespace, name, volumeName string) error
+	FnSecretCreateOrUpdate        func(ctx context.Context, secret corev1.Secret) error
+	FnSecretGet                   func(ctx context.Context, namespace, name string) (*corev1.Secret, error)
+	FnServerVersionGet            func() (string, error)
+	FnServiceGet                  func(ctx context.Context, namespace, name string) (*corev1.Service, error)
+	FnEventsWatch                 func(ctx context.Context, namespace string) (watch.Interface, error)
+	FnLogsGet                     func(ctx context.Context, namespace string, name string) (string, error)
+}
+
+func (m *MockClient) DeploymentList(ctx context.Context, namespace string) (*v1.DeploymentList, error) {
+	return m.FnDeploymentList(ctx, namespace)
+}
+
+func (m *MockClient) DeploymentRestart(ctx context.Context, namespace, name string) error {
+	if m.FnDeploymentRestart == nil {
+		return m.FnDeploymentRestart(ctx, namespace, name)
+	}
+	return nil
+}
+
+func (m *MockClient) IngressCreate(ctx context.Context, namespace string, ingress *networkingv1.Ingress) error {
+	if m.FnIngressCreate != nil {
+		return m.FnIngressCreate(ctx, namespace, ingress)
+	}
+	return nil
+}
+
+func (m *MockClient) IngressExists(ctx context.Context, namespace string, ingress string) bool {
+	if m.FnIngressExists != nil {
+		return m.FnIngressExists(ctx, namespace, ingress)
+	}
+	return true
+}
+
+func (m *MockClient) IngressUpdate(ctx context.Context, namespace string, ingress *networkingv1.Ingress) error {
+	if m.FnIngressUpdate != nil {
+		return m.FnIngressUpdate(ctx, namespace, ingress)
+	}
+	return nil
+}
+
+func (m *MockClient) NamespaceCreate(ctx context.Context, namespace string) error {
+	if m.FnNamespaceCreate != nil {
+		return m.FnNamespaceCreate(ctx, namespace)
+	}
+	return nil
+}
+
+func (m *MockClient) NamespaceExists(ctx context.Context, namespace string) bool {
+	if m.FnNamespaceExists != nil {
+		return m.FnNamespaceExists(ctx, namespace)
+	}
+	return true
+}
+
+func (m *MockClient) NamespaceDelete(ctx context.Context, namespace string) error {
+	if m.FnNamespaceDelete != nil {
+		return m.FnNamespaceDelete(ctx, namespace)
+	}
+	return nil
+}
+
+func (m *MockClient) PersistentVolumeCreate(ctx context.Context, namespace, name string) error {
+	if m.FnPersistentVolumeCreate != nil {
+		return m.FnPersistentVolumeCreate(ctx, namespace, name)
+	}
+	return nil
+}
+func (m *MockClient) PersistentVolumeExists(ctx context.Context, namespace, name string) bool {
+	if m.FnPersistentVolumeExists != nil {
+		return m.FnPersistentVolumeExists(ctx, namespace, name)
+	}
+	return true
+}
+func (m *MockClient) PersistentVolumeDelete(ctx context.Context, namespace, name string) error {
+	if m.FnPersistentVolumeDelete != nil {
+		return m.FnPersistentVolumeDelete(ctx, namespace, name)
+	}
+	return nil
+}
+
+func (m *MockClient) PersistentVolumeClaimCreate(ctx context.Context, namespace, name, volumeName string) error {
+	if m.FnPersistentVolumeClaimCreate != nil {
+		return m.FnPersistentVolumeClaimCreate(ctx, namespace, name, volumeName)
+	}
+	return nil
+}
+func (m *MockClient) PersistentVolumeClaimExists(ctx context.Context, namespace, name, volumeName string) bool {
+	if m.FnPersistentVolumeClaimExists != nil {
+		return m.FnPersistentVolumeClaimExists(ctx, namespace, name, volumeName)
+	}
+	return true
+}
+func (m *MockClient) PersistentVolumeClaimDelete(ctx context.Context, namespace, name, volumeName string) error {
+	if m.FnPersistentVolumeClaimDelete != nil {
+		return m.FnPersistentVolumeClaimDelete(ctx, namespace, name, volumeName)
+	}
+	return nil
+}
+
+func (m *MockClient) SecretCreateOrUpdate(ctx context.Context, secret corev1.Secret) error {
+	if m.FnSecretCreateOrUpdate != nil {
+		return m.FnSecretCreateOrUpdate(ctx, secret)
+	}
+
+	return nil
+}
+
+func (m *MockClient) SecretGet(ctx context.Context, namespace, name string) (*corev1.Secret, error) {
+	if m.FnSecretGet != nil {
+		return m.FnSecretGet(ctx, namespace, name)
+	}
+
+	return nil, nil
+}
+
+func (m *MockClient) ServiceGet(ctx context.Context, namespace, name string) (*corev1.Service, error) {
+	return m.FnServiceGet(ctx, namespace, name)
+}
+
+func (m *MockClient) ServerVersionGet() (string, error) {
+	if m.FnServerVersionGet != nil {
+		return m.FnServerVersionGet()
+	}
+	return "test", nil
+}
+
+func (m *MockClient) EventsWatch(ctx context.Context, namespace string) (watch.Interface, error) {
+	if m.FnEventsWatch == nil {
+		return watch.NewFake(), nil
+	}
+	return m.FnEventsWatch(ctx, namespace)
+}
+
+func (m *MockClient) LogsGet(ctx context.Context, namespace string, name string) (string, error) {
+	if m.FnLogsGet == nil {
+		return "LogsGet called", nil
+	}
+	return m.FnLogsGet(ctx, namespace, name)
+}

--- a/internal/cmd/local/local.go
+++ b/internal/cmd/local/local.go
@@ -15,6 +15,7 @@ import (
 type Cmd struct {
 	Credentials CredentialsCmd `cmd:"" help:"Get local Airbyte user credentials."`
 	Install     InstallCmd     `cmd:"" help:"Install local Airbyte."`
+	Deployments DeploymentsCmd `cmd:"" help:"View local Airbyte deployments."`
 	Status      StatusCmd      `cmd:"" help:"Get local Airbyte status."`
 	Uninstall   UninstallCmd   `cmd:"" help:"Uninstall local Airbyte."`
 }

--- a/internal/cmd/local/local.go
+++ b/internal/cmd/local/local.go
@@ -29,15 +29,12 @@ func (c *Cmd) BeforeApply() error {
 }
 
 func (c *Cmd) AfterApply(provider k8s.Provider) error {
-	printProviderDetails(provider)
-	return nil
-}
-
-func printProviderDetails(p k8s.Provider) {
 	pterm.Info.Println(fmt.Sprintf(
 		"Using Kubernetes provider:\n  Provider: %s\n  Kubeconfig: %s\n  Context: %s",
-		p.Name, p.Kubeconfig, p.Context,
+		provider.Name, provider.Kubeconfig, provider.Context,
 	))
+
+	return nil
 }
 
 // checkAirbyteDir verifies that, if the paths.Airbyte directory exists, that it has proper permissions.

--- a/internal/cmd/local/local/cmd_test.go
+++ b/internal/cmd/local/local/cmd_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/airbytehq/abctl/internal/cmd/local/helm"
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
+	"github.com/airbytehq/abctl/internal/cmd/local/k8s/k8stest"
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
@@ -20,10 +21,8 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/repo"
-	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/watch"
 )
 
 const portTest = 9999
@@ -149,17 +148,17 @@ func TestCommand_Install(t *testing.T) {
 		},
 	}
 
-	k8sClient := mockK8sClient{
-		serverVersionGet: func() (string, error) {
+	k8sClient := k8stest.MockClient{
+		FnServerVersionGet: func() (string, error) {
 			return "test", nil
 		},
-		secretCreateOrUpdate: func(ctx context.Context, secret corev1.Secret) error {
+		FnSecretCreateOrUpdate: func(ctx context.Context, secret corev1.Secret) error {
 			return nil
 		},
-		ingressExists: func(ctx context.Context, namespace string, ingress string) bool {
+		FnIngressExists: func(ctx context.Context, namespace string, ingress string) bool {
 			return false
 		},
-		ingressCreate: func(ctx context.Context, namespace string, ingress *networkingv1.Ingress) error {
+		FnIngressCreate: func(ctx context.Context, namespace string, ingress *networkingv1.Ingress) error {
 			return nil
 		},
 	}
@@ -317,17 +316,17 @@ func TestCommand_Install_ValuesFile(t *testing.T) {
 		},
 	}
 
-	k8sClient := mockK8sClient{
-		serverVersionGet: func() (string, error) {
+	k8sClient := k8stest.MockClient{
+		FnServerVersionGet: func() (string, error) {
 			return "test", nil
 		},
-		secretCreateOrUpdate: func(ctx context.Context, secret corev1.Secret) error {
+		FnSecretCreateOrUpdate: func(ctx context.Context, secret corev1.Secret) error {
 			return nil
 		},
-		ingressExists: func(ctx context.Context, namespace string, ingress string) bool {
+		FnIngressExists: func(ctx context.Context, namespace string, ingress string) bool {
 			return false
 		},
-		ingressCreate: func(ctx context.Context, namespace string, ingress *networkingv1.Ingress) error {
+		FnIngressCreate: func(ctx context.Context, namespace string, ingress *networkingv1.Ingress) error {
 			return nil
 		},
 	}
@@ -368,7 +367,7 @@ func TestCommand_Install_InvalidValuesFile(t *testing.T) {
 		k8s.TestProvider,
 		WithPortHTTP(portTest),
 		WithHelmClient(&mockHelmClient{}),
-		WithK8sClient(&mockK8sClient{}),
+		WithK8sClient(&k8stest.MockClient{}),
 		WithTelemetryClient(&mockTelemetryClient{}),
 		WithHTTPClient(&mockHTTP{}),
 		WithBrowserLauncher(func(url string) error {
@@ -423,163 +422,6 @@ func (m *mockHelmClient) InstallOrUpgradeChart(ctx context.Context, spec *helmcl
 
 func (m *mockHelmClient) UninstallReleaseByName(s string) error {
 	return m.uninstallReleaseByName(s)
-}
-
-var _ k8s.Client = (*mockK8sClient)(nil)
-
-type mockK8sClient struct {
-	deploymentRestart           func(ctx context.Context, namespace, name string) error
-	ingressCreate               func(ctx context.Context, namespace string, ingress *networkingv1.Ingress) error
-	ingressExists               func(ctx context.Context, namespace string, ingress string) bool
-	ingressUpdate               func(ctx context.Context, namespace string, ingress *networkingv1.Ingress) error
-	namespaceCreate             func(ctx context.Context, namespace string) error
-	namespaceExists             func(ctx context.Context, namespace string) bool
-	namespaceDelete             func(ctx context.Context, namespace string) error
-	persistentVolumeCreate      func(ctx context.Context, namespace, name string) error
-	persistentVolumeExists      func(ctx context.Context, namespace, name string) bool
-	persistentVolumeDelete      func(ctx context.Context, namespace, name string) error
-	persistentVolumeClaimCreate func(ctx context.Context, namespace, name, volumeName string) error
-	persistentVolumeClaimExists func(ctx context.Context, namespace, name, volumeName string) bool
-	persistentVolumeClaimDelete func(ctx context.Context, namespace, name, volumeName string) error
-	secretCreateOrUpdate        func(ctx context.Context, secret corev1.Secret) error
-	secretGet                   func(ctx context.Context, namespace, name string) (*corev1.Secret, error)
-	serverVersionGet            func() (string, error)
-	serviceGet                  func(ctx context.Context, namespace, name string) (*corev1.Service, error)
-	deploymentList              func(ctx context.Context, namespace string) (*v1.DeploymentList, error)
-	eventsWatch                 func(ctx context.Context, namespace string) (watch.Interface, error)
-	logsGet                     func(ctx context.Context, namespace string, name string) (string, error)
-}
-
-func (m *mockK8sClient) DeploymentList(ctx context.Context, namespace string) (*v1.DeploymentList, error) {
-	return m.deploymentList(ctx, namespace)
-}
-
-func (m *mockK8sClient) DeploymentRestart(ctx context.Context, namespace, name string) error {
-	if m.deploymentRestart == nil {
-		return m.deploymentRestart(ctx, namespace, name)
-	}
-	return nil
-}
-
-func (m *mockK8sClient) IngressCreate(ctx context.Context, namespace string, ingress *networkingv1.Ingress) error {
-	if m.ingressCreate != nil {
-		return m.ingressCreate(ctx, namespace, ingress)
-	}
-	return nil
-}
-
-func (m *mockK8sClient) IngressExists(ctx context.Context, namespace string, ingress string) bool {
-	if m.ingressExists != nil {
-		return m.ingressExists(ctx, namespace, ingress)
-	}
-	return true
-}
-
-func (m *mockK8sClient) IngressUpdate(ctx context.Context, namespace string, ingress *networkingv1.Ingress) error {
-	if m.ingressUpdate != nil {
-		return m.ingressUpdate(ctx, namespace, ingress)
-	}
-	return nil
-}
-
-func (m *mockK8sClient) NamespaceCreate(ctx context.Context, namespace string) error {
-	if m.namespaceCreate != nil {
-		return m.namespaceCreate(ctx, namespace)
-	}
-	return nil
-}
-
-func (m *mockK8sClient) NamespaceExists(ctx context.Context, namespace string) bool {
-	if m.namespaceExists != nil {
-		return m.namespaceExists(ctx, namespace)
-	}
-	return true
-}
-
-func (m *mockK8sClient) NamespaceDelete(ctx context.Context, namespace string) error {
-	if m.namespaceDelete != nil {
-		return m.namespaceDelete(ctx, namespace)
-	}
-	return nil
-}
-
-func (m *mockK8sClient) PersistentVolumeCreate(ctx context.Context, namespace, name string) error {
-	if m.persistentVolumeCreate != nil {
-		return m.persistentVolumeCreate(ctx, namespace, name)
-	}
-	return nil
-}
-func (m *mockK8sClient) PersistentVolumeExists(ctx context.Context, namespace, name string) bool {
-	if m.persistentVolumeExists != nil {
-		return m.persistentVolumeExists(ctx, namespace, name)
-	}
-	return true
-}
-func (m *mockK8sClient) PersistentVolumeDelete(ctx context.Context, namespace, name string) error {
-	if m.persistentVolumeDelete != nil {
-		return m.persistentVolumeDelete(ctx, namespace, name)
-	}
-	return nil
-}
-
-func (m *mockK8sClient) PersistentVolumeClaimCreate(ctx context.Context, namespace, name, volumeName string) error {
-	if m.persistentVolumeClaimCreate != nil {
-		return m.persistentVolumeClaimCreate(ctx, namespace, name, volumeName)
-	}
-	return nil
-}
-func (m *mockK8sClient) PersistentVolumeClaimExists(ctx context.Context, namespace, name, volumeName string) bool {
-	if m.persistentVolumeClaimExists != nil {
-		return m.persistentVolumeClaimExists(ctx, namespace, name, volumeName)
-	}
-	return true
-}
-func (m *mockK8sClient) PersistentVolumeClaimDelete(ctx context.Context, namespace, name, volumeName string) error {
-	if m.persistentVolumeClaimDelete != nil {
-		return m.persistentVolumeClaimDelete(ctx, namespace, name, volumeName)
-	}
-	return nil
-}
-
-func (m *mockK8sClient) SecretCreateOrUpdate(ctx context.Context, secret corev1.Secret) error {
-	if m.secretCreateOrUpdate != nil {
-		return m.secretCreateOrUpdate(ctx, secret)
-	}
-
-	return nil
-}
-
-func (m *mockK8sClient) SecretGet(ctx context.Context, namespace, name string) (*corev1.Secret, error) {
-	if m.secretGet != nil {
-		return m.secretGet(ctx, namespace, name)
-	}
-
-	return nil, nil
-}
-
-func (m *mockK8sClient) ServiceGet(ctx context.Context, namespace, name string) (*corev1.Service, error) {
-	return m.serviceGet(ctx, namespace, name)
-}
-
-func (m *mockK8sClient) ServerVersionGet() (string, error) {
-	if m.serverVersionGet != nil {
-		return m.serverVersionGet()
-	}
-	return "test", nil
-}
-
-func (m *mockK8sClient) EventsWatch(ctx context.Context, namespace string) (watch.Interface, error) {
-	if m.eventsWatch == nil {
-		return watch.NewFake(), nil
-	}
-	return m.eventsWatch(ctx, namespace)
-}
-
-func (m *mockK8sClient) LogsGet(ctx context.Context, namespace string, name string) (string, error) {
-	if m.logsGet == nil {
-		return "LogsGet called", nil
-	}
-	return m.logsGet(ctx, namespace, name)
 }
 
 var _ telemetry.Client = (*mockTelemetryClient)(nil)

--- a/internal/cmd/local/local/cmd_test.go
+++ b/internal/cmd/local/local/cmd_test.go
@@ -20,7 +20,8 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/repo"
-	coreV1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
@@ -152,7 +153,7 @@ func TestCommand_Install(t *testing.T) {
 		serverVersionGet: func() (string, error) {
 			return "test", nil
 		},
-		secretCreateOrUpdate: func(ctx context.Context, secret coreV1.Secret) error {
+		secretCreateOrUpdate: func(ctx context.Context, secret corev1.Secret) error {
 			return nil
 		},
 		ingressExists: func(ctx context.Context, namespace string, ingress string) bool {
@@ -320,7 +321,7 @@ func TestCommand_Install_ValuesFile(t *testing.T) {
 		serverVersionGet: func() (string, error) {
 			return "test", nil
 		},
-		secretCreateOrUpdate: func(ctx context.Context, secret coreV1.Secret) error {
+		secretCreateOrUpdate: func(ctx context.Context, secret corev1.Secret) error {
 			return nil
 		},
 		ingressExists: func(ctx context.Context, namespace string, ingress string) bool {
@@ -440,12 +441,17 @@ type mockK8sClient struct {
 	persistentVolumeClaimCreate func(ctx context.Context, namespace, name, volumeName string) error
 	persistentVolumeClaimExists func(ctx context.Context, namespace, name, volumeName string) bool
 	persistentVolumeClaimDelete func(ctx context.Context, namespace, name, volumeName string) error
-	secretCreateOrUpdate        func(ctx context.Context, secret coreV1.Secret) error
-	secretGet                   func(ctx context.Context, namespace, name string) (*coreV1.Secret, error)
-	serviceGet                  func(ctx context.Context, namespace, name string) (*coreV1.Service, error)
+	secretCreateOrUpdate        func(ctx context.Context, secret corev1.Secret) error
+	secretGet                   func(ctx context.Context, namespace, name string) (*corev1.Secret, error)
 	serverVersionGet            func() (string, error)
+	serviceGet                  func(ctx context.Context, namespace, name string) (*corev1.Service, error)
+	deploymentList              func(ctx context.Context, namespace string) (*v1.DeploymentList, error)
 	eventsWatch                 func(ctx context.Context, namespace string) (watch.Interface, error)
 	logsGet                     func(ctx context.Context, namespace string, name string) (string, error)
+}
+
+func (m *mockK8sClient) DeploymentList(ctx context.Context, namespace string) (*v1.DeploymentList, error) {
+	return m.deploymentList(ctx, namespace)
 }
 
 func (m *mockK8sClient) DeploymentRestart(ctx context.Context, namespace, name string) error {
@@ -535,7 +541,7 @@ func (m *mockK8sClient) PersistentVolumeClaimDelete(ctx context.Context, namespa
 	return nil
 }
 
-func (m *mockK8sClient) SecretCreateOrUpdate(ctx context.Context, secret coreV1.Secret) error {
+func (m *mockK8sClient) SecretCreateOrUpdate(ctx context.Context, secret corev1.Secret) error {
 	if m.secretCreateOrUpdate != nil {
 		return m.secretCreateOrUpdate(ctx, secret)
 	}
@@ -543,7 +549,7 @@ func (m *mockK8sClient) SecretCreateOrUpdate(ctx context.Context, secret coreV1.
 	return nil
 }
 
-func (m *mockK8sClient) SecretGet(ctx context.Context, namespace, name string) (*coreV1.Secret, error) {
+func (m *mockK8sClient) SecretGet(ctx context.Context, namespace, name string) (*corev1.Secret, error) {
 	if m.secretGet != nil {
 		return m.secretGet(ctx, namespace, name)
 	}
@@ -551,7 +557,7 @@ func (m *mockK8sClient) SecretGet(ctx context.Context, namespace, name string) (
 	return nil, nil
 }
 
-func (m *mockK8sClient) ServiceGet(ctx context.Context, namespace, name string) (*coreV1.Service, error) {
+func (m *mockK8sClient) ServiceGet(ctx context.Context, namespace, name string) (*corev1.Service, error) {
 	return m.serviceGet(ctx, namespace, name)
 }
 

--- a/internal/cmd/local/local_credentials.go
+++ b/internal/cmd/local/local_credentials.go
@@ -104,10 +104,10 @@ func (cc *CredentialsCmd) Run(ctx context.Context, provider k8s.Provider, telCli
 }
 
 func defaultK8s(kubecfg, kubectx string) (k8s.Client, error) {
-	k8sCfg, err := k8sClientConfig(kubecfg, kubectx)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %w", localerr.ErrKubernetes, err)
-	}
+	k8sCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubecfg},
+		&clientcmd.ConfigOverrides{CurrentContext: kubectx},
+	)
 
 	restCfg, err := k8sCfg.ClientConfig()
 	if err != nil {
@@ -119,12 +119,4 @@ func defaultK8s(kubecfg, kubectx string) (k8s.Client, error) {
 	}
 
 	return &k8s.DefaultK8sClient{ClientSet: k8sClient}, nil
-}
-
-// k8sClientConfig returns a k8s client config using the ~/.kube/config file and the k8sContext context.
-func k8sClientConfig(kubecfg, kubectx string) (clientcmd.ClientConfig, error) {
-	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubecfg},
-		&clientcmd.ConfigOverrides{CurrentContext: kubectx},
-	), nil
 }

--- a/internal/cmd/local/local_credentials.go
+++ b/internal/cmd/local/local_credentials.go
@@ -93,7 +93,7 @@ func (cc *CredentialsCmd) Run(ctx context.Context, provider k8s.Provider, telCli
 			orgEmail = "[not set]"
 		}
 
-		pterm.Success.Println(fmt.Sprintf("Retreiving your credentials from '%s'", secret.Name))
+		pterm.Success.Println(fmt.Sprintf("Retrieving your credentials from '%s'", secret.Name))
 		pterm.Info.Println(fmt.Sprintf(`Credentials:
   Email: %s
   Password: %s

--- a/internal/cmd/local/local_deployments.go
+++ b/internal/cmd/local/local_deployments.go
@@ -19,7 +19,7 @@ func (d *DeploymentsCmd) Run(ctx context.Context, telClient telemetry.Client, k8
 		return err
 	}
 
-	return telClient.Wrap(ctx, telemetry.Restart, func() error {
+	return telClient.Wrap(ctx, telemetry.Deployments, func() error {
 		return d.deployments(ctx, k8sClient, spinner)
 	})
 }

--- a/internal/cmd/local/local_deployments.go
+++ b/internal/cmd/local/local_deployments.go
@@ -1,0 +1,62 @@
+package local
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
+	"github.com/airbytehq/abctl/internal/telemetry"
+	"github.com/pterm/pterm"
+)
+
+type DeploymentsCmd struct {
+	Restart string `help:"Deployment to restart."`
+}
+
+func (d *DeploymentsCmd) Run(ctx context.Context, provider k8s.Provider, telClient telemetry.Client) error {
+	spinner := &pterm.DefaultSpinner
+	if err := checkDocker(ctx, telClient, spinner); err != nil {
+		return err
+	}
+
+	return telClient.Wrap(ctx, telemetry.Restart, func() error {
+		return d.deployments(ctx, provider, telClient, spinner)
+	})
+}
+
+func (d *DeploymentsCmd) deployments(ctx context.Context, provider k8s.Provider, telClient telemetry.Client, spinner *pterm.SpinnerPrinter) error {
+	k8sClient, err := defaultK8s(provider.Kubeconfig, provider.Context)
+	if err != nil {
+		pterm.Error.Println("No existing cluster found")
+		return nil
+	}
+
+	if d.Restart == "" {
+		spinner.UpdateText("Fetching deployments")
+		svcs, err := k8sClient.DeploymentList(ctx, airbyteNamespace)
+		if err != nil {
+			pterm.Error.Println("Unable to list deployments")
+			return fmt.Errorf("unable to list deployments: %w", err)
+		}
+
+		if len(svcs.Items) == 0 {
+			pterm.Info.Println("No deployments found")
+			return nil
+		}
+		output := "Found the following deployments:"
+		for _, svc := range svcs.Items {
+			output += "\n  " + svc.Name
+		}
+		pterm.Info.Println(output)
+
+		return nil
+	}
+
+	spinner.UpdateText(fmt.Sprintf("Restarting deployment %s", d.Restart))
+	if err := k8sClient.DeploymentRestart(ctx, airbyteNamespace, d.Restart); err != nil {
+		pterm.Error.Println(fmt.Sprintf("Unable to restart airbyte deployment %s", d.Restart))
+		return fmt.Errorf("unable to restart airbyte deployment: %w", err)
+	}
+
+	return nil
+}

--- a/internal/cmd/local/local_deployments_test.go
+++ b/internal/cmd/local/local_deployments_test.go
@@ -1,0 +1,104 @@
+package local
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/airbytehq/abctl/internal/cmd/local/k8s/k8stest"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pterm/pterm"
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDeploymentsCmd(t *testing.T) {
+	b := bytes.NewBufferString("")
+	pterm.SetDefaultOutput(b)
+	pterm.EnableDebugMessages()
+	// remove color codes from output
+	pterm.DisableColor()
+	t.Cleanup(func() {
+		pterm.SetDefaultOutput(os.Stdout)
+		pterm.DisableDebugMessages()
+		pterm.EnableColor()
+	})
+
+	ctx := context.Background()
+	t.Run("two deployments", func(t *testing.T) {
+		b.Reset()
+
+		mockK8s := &k8stest.MockClient{
+			FnDeploymentList: func(ctx context.Context, namespace string) (*v1.DeploymentList, error) {
+				if d := cmp.Diff(airbyteNamespace, namespace); d != "" {
+					t.Errorf("unexpected namespace:\n%s", d)
+				}
+
+				return &v1.DeploymentList{
+					Items: []v1.Deployment{
+						{ObjectMeta: metav1.ObjectMeta{Name: "deployment0"}},
+						{ObjectMeta: metav1.ObjectMeta{Name: "deployment1"}},
+					},
+				}, nil
+			},
+		}
+
+		cmd := &DeploymentsCmd{}
+		err := cmd.deployments(ctx, mockK8s, &pterm.DefaultSpinner)
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		if !strings.Contains(b.String(), "deployment0") {
+			t.Error("missing deployment0 from output")
+		}
+		if !strings.Contains(b.String(), "deployment1") {
+			t.Error("missing deployment1 from output")
+		}
+	})
+
+	t.Run("no deployments", func(t *testing.T) {
+		b.Reset()
+
+		mockK8s := &k8stest.MockClient{
+			FnDeploymentList: func(ctx context.Context, namespace string) (*v1.DeploymentList, error) {
+				if d := cmp.Diff(airbyteNamespace, namespace); d != "" {
+					t.Errorf("unexpected namespace:\n%s", d)
+				}
+
+				return &v1.DeploymentList{Items: []v1.Deployment{}}, nil
+			},
+		}
+
+		cmd := &DeploymentsCmd{}
+		err := cmd.deployments(ctx, mockK8s, &pterm.DefaultSpinner)
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+
+		if !strings.Contains(b.String(), "No deployments found") {
+			t.Error("missing 'No deployments found' from output")
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		b.Reset()
+
+		errTest := errors.New("test error")
+		mockK8s := &k8stest.MockClient{
+			FnDeploymentList: func(ctx context.Context, namespace string) (*v1.DeploymentList, error) {
+				return nil, errTest
+			},
+		}
+
+		cmd := &DeploymentsCmd{}
+		err := cmd.deployments(ctx, mockK8s, &pterm.DefaultSpinner)
+		if d := cmp.Diff(errTest, err, cmpopts.EquateErrors()); d != "" {
+			t.Errorf("error mismatch (-want +got):\n%s", d)
+		}
+	})
+}

--- a/internal/cmd/local/localerr/localerr.go
+++ b/internal/cmd/local/localerr/localerr.go
@@ -6,6 +6,9 @@ var (
 	// ErrAirbyteDir is returned anytime an there is an issue in accessing the paths.Airbyte directory.
 	ErrAirbyteDir = errors.New("airbyte directory is inaccessible")
 
+	// ErrClusterNotFound is returned in the event that no cluster was located.
+	ErrClusterNotFound = errors.New("no existing cluster found")
+
 	// ErrDocker is returned anytime an error occurs when attempting to communicate with docker.
 	ErrDocker = errors.New("error communicating with docker")
 

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -27,6 +27,7 @@ const (
 	Credentials EventType = "credentials"
 	Install               = "install"
 	Migrate               = "migrate"
+	Restart               = "restart"
 	Status                = "status"
 	Uninstall             = "uninstall"
 )

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -25,9 +25,9 @@ type EventType string
 
 const (
 	Credentials EventType = "credentials"
+	Deployments           = "deployments"
 	Install               = "install"
 	Migrate               = "migrate"
-	Restart               = "restart"
 	Status                = "status"
 	Uninstall             = "uninstall"
 )

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ func main() {
 	}
 }
 
+// bindCtx exists to allow kong to correctly inject a context.Context into the Run methods on the commands.
 func bindCtx(ctx context.Context) func() (context.Context, error) {
 	return func() (context.Context, error) {
 		return ctx, nil


### PR DESCRIPTION
- fix https://github.com/airbytehq/airbyte-internal-issues/issues/9582
- add a `abctl local deployments` sub command
    - by default will list all the deployments
    - if passed `--restart=[deployment name]`, will restart the provided deployment
- add `k8stest` package
    - moved `mockK8Client` (from the existing tests) to `MockClient` in this package
    - follows a similar model that the package `dockertest` uses
- update the default `k8s.Client` to be injectable (in `kong`)
    - this enabled me to write tests for the `deployment` sub-command
    - also adds the ability to write tests easier for other sub-commands (not in this PR)