### PR TITLE
feat: add the host.docker.internal to the ingress so that dockerized apps can easily communicate with Airbyte.

### DIFF
--- a/internal/cmd/local/local/specs.go
+++ b/internal/cmd/local/local/specs.go
@@ -11,11 +11,10 @@ import (
 func ingress(host string) *networkingv1.Ingress {
 	var ingressClassName = "nginx"
 
-	// Always add a localhost route.
+	// Always add a localhost and host.docker.internal route.
 	// This is necessary to ensure that this code can verify the Airbyte installation via `localhost`.
-	rules := []networkingv1.IngressRule{ingressRule("localhost")}
-	// Make it easy for dockerized applications, like Airflow to communicate with Airbyte
-	rules = append(rules, ingressRule("host.docker.internal"))
+	// Additionally, make it easy for dockerized applications (Airflow) to talk with Airbyte over the docker host.
+	rules := []networkingv1.IngressRule{ingressRule("localhost"), ingressRule("host.docker.internal")}
 	// If a host that isn't `localhost` was provided, create a second rule for that host.
 	// This is required to support non-local installation, such as running on an EC2 instance.
 	if host != "localhost" {

--- a/internal/cmd/local/local/specs.go
+++ b/internal/cmd/local/local/specs.go
@@ -14,6 +14,8 @@ func ingress(host string) *networkingv1.Ingress {
 	// Always add a localhost route.
 	// This is necessary to ensure that this code can verify the Airbyte installation via `localhost`.
 	rules := []networkingv1.IngressRule{ingressRule("localhost")}
+	// Make it easy for dockerized applications, like Airflow to communicate with Airbyte
+	rules = append(rules, ingressRule("host.docker.internal"))
 	// If a host that isn't `localhost` was provided, create a second rule for that host.
 	// This is required to support non-local installation, such as running on an EC2 instance.
 	if host != "localhost" {


### PR DESCRIPTION
Add the host.docker.internal to the ingress so that dockerized apps can easily communicate with Airbyte.