### PR TITLE
fix: improve port checks

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -42,7 +42,7 @@ This could be in indication that the ingress port is already in use by a differe
 The ingress port can be changed by passing the flag --port.`
 
 	// helpPort is displayed if ErrPort is ever returned
-	helpPort = `An error occurred while verifying if the request port is available.
+	helpPort = `An error occurred while verifying if the requested port is available.
 This could be in indication that the ingress port is already in use by a different application.
 The ingress port can be changed by passing the flag --port.`
 )

--- a/internal/cmd/local/check_test.go
+++ b/internal/cmd/local/check_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/airbytehq/abctl/internal/cmd/local/localerr"
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/system"
+	"github.com/docker/go-connections/nat"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 )
@@ -110,6 +112,142 @@ func TestPortAvailable_Unavailable(t *testing.T) {
 	}
 	if !errors.Is(err, localerr.ErrPort) {
 		t.Error("error should be of type ErrPort")
+	}
+}
+
+func TestGetPort_Found(t *testing.T) {
+	t.Cleanup(func() {
+		dockerClient = nil
+	})
+
+	dockerClient = &docker.Docker{
+		Client: dockertest.MockClient{
+			FnContainerInspect: func(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+				return types.ContainerJSON{
+					ContainerJSONBase: &types.ContainerJSONBase{
+						State: &types.ContainerState{
+							Status: "running",
+						},
+						HostConfig: &container.HostConfig{
+							PortBindings: nat.PortMap{
+								"tcp/80": {{
+									HostIP:   "0.0.0.0",
+									HostPort: "8000",
+								}},
+							},
+						},
+					},
+				}, nil
+			},
+		},
+	}
+
+	port, err := getPort(context.Background(), "test")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+		return
+	}
+	if port != 8000 {
+		t.Errorf("expected 8000 but got %d", port)
+	}
+}
+
+func TestGetPort_NotRunning(t *testing.T) {
+	t.Cleanup(func() {
+		dockerClient = nil
+	})
+
+	dockerClient = &docker.Docker{
+		Client: dockertest.MockClient{
+			FnContainerInspect: func(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+				return types.ContainerJSON{
+					ContainerJSONBase: &types.ContainerJSONBase{
+						State: &types.ContainerState{
+							Status: "stopped",
+						},
+						HostConfig: &container.HostConfig{
+							PortBindings: nat.PortMap{
+								"tcp/80": {{
+									HostIP:   "0.0.0.0",
+									HostPort: "8000",
+								}},
+							},
+						},
+					},
+				}, nil
+			},
+		},
+	}
+
+	_, err := getPort(context.Background(), "test")
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestGetPort_Missing(t *testing.T) {
+	t.Cleanup(func() {
+		dockerClient = nil
+	})
+
+	dockerClient = &docker.Docker{
+		Client: dockertest.MockClient{
+			FnContainerInspect: func(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+				return types.ContainerJSON{
+					ContainerJSONBase: &types.ContainerJSONBase{
+						State: &types.ContainerState{
+							Status: "running",
+						},
+						HostConfig: &container.HostConfig{
+							PortBindings: nat.PortMap{
+								"tcp/80": {{
+									HostIP:   "1.2.3.4",
+									HostPort: "8000",
+								}},
+							},
+						},
+					},
+				}, nil
+			},
+		},
+	}
+
+	_, err := getPort(context.Background(), "test")
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestGetPort_Invalid(t *testing.T) {
+	t.Cleanup(func() {
+		dockerClient = nil
+	})
+
+	dockerClient = &docker.Docker{
+		Client: dockertest.MockClient{
+			FnContainerInspect: func(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+				return types.ContainerJSON{
+					ContainerJSONBase: &types.ContainerJSONBase{
+						State: &types.ContainerState{
+							Status: "running",
+						},
+						HostConfig: &container.HostConfig{
+							PortBindings: nat.PortMap{
+								"tcp/80": {{
+									HostIP:   "1.2.3.4",
+									HostPort: "NaN",
+								}},
+							},
+						},
+					},
+				}, nil
+			},
+		},
+	}
+
+	_, err := getPort(context.Background(), "test")
+	if err == nil {
+		t.Error("expected error")
 	}
 }
 

--- a/internal/cmd/local/docker/docker.go
+++ b/internal/cmd/local/docker/docker.go
@@ -2,11 +2,9 @@ package docker
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"runtime"
-	"strconv"
 
 	"github.com/airbytehq/abctl/internal/cmd/local/localerr"
 	"github.com/airbytehq/abctl/internal/cmd/local/paths"
@@ -152,27 +150,4 @@ func (d *Docker) Version(ctx context.Context) (Version, error) {
 		Arch:     ver.Arch,
 		Platform: ver.Platform.Name,
 	}, nil
-}
-
-// Port returns the host-port the underlying docker process is currently bound to, for the given container.
-// It determines this by walking through all the ports on the container and finding the one that is bound to ip 0.0.0.0.
-func (d *Docker) Port(ctx context.Context, container string) (int, error) {
-	ci, err := d.Client.ContainerInspect(ctx, container)
-	if err != nil {
-		return 0, fmt.Errorf("unable to inspect container: %w", err)
-	}
-
-	for _, bindings := range ci.NetworkSettings.Ports {
-		for _, ipPort := range bindings {
-			if ipPort.HostIP == "0.0.0.0" {
-				port, err := strconv.Atoi(ipPort.HostPort)
-				if err != nil {
-					return 0, fmt.Errorf("unable to convert host port %s to integer: %w", ipPort.HostPort, err)
-				}
-				return port, nil
-			}
-		}
-	}
-
-	return 0, errors.New("unable to determine port for container")
 }

--- a/internal/cmd/local/local_credentials.go
+++ b/internal/cmd/local/local_credentials.go
@@ -45,7 +45,7 @@ func (cc *CredentialsCmd) Run(ctx context.Context, provider k8s.Provider, telCli
 		clientId := string(secret.Data[secretClientID])
 		clientSecret := string(secret.Data[secretClientSecret])
 
-		port, err := getPort(ctx, provider)
+		port, err := getPort(ctx, provider.ClusterName)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -58,10 +58,11 @@ func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient t
 				providedPort := i.Port
 				i.Port, err = getPort(ctx, provider.ClusterName)
 				if err != nil {
-					pterm.Warning.Printfln("Unable to determine which port the existing cluster was configured to use.\n" +
-						"Installation will continue but may ultimately fail, in which case it will be necessarily to uninstall first.")
+					return err
+					// pterm.Warning.Printfln("Unable to determine which port the existing cluster was configured to use.\n" +
+						// "Installation will continue but may ultimately fail, in which case it will be necessarily to uninstall first.")
 					// since we can't verify the port is correct, push forward with the provided port
-					i.Port = providedPort
+					// i.Port = providedPort
 				}
 				if providedPort != i.Port {
 					pterm.Warning.Printfln("The existing cluster was found to be using port %d, which differs from the provided port %d.\n"+

--- a/internal/cmd/local/local_status.go
+++ b/internal/cmd/local/local_status.go
@@ -53,7 +53,7 @@ func status(ctx context.Context, provider k8s.Provider, telClient telemetry.Clie
 	pterm.Success.Printfln("Existing cluster '%s' found", provider.ClusterName)
 	spinner.UpdateText(fmt.Sprintf("Validating existing cluster '%s'", provider.ClusterName))
 
-	port, err := getPort(ctx, provider)
+	port, err := getPort(ctx, provider.ClusterName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR is doing a few things related to improving the port checks (`portAvailable` and `getPort`):
- `getPort` checks that the container status is `running` and returns an error otherwise
- `portAvailable` is only called when installing a new cluster (no existing cluster)
- `portAvailable` a nicer error message by looking for "address in use" error codes.
- `portAvailable` doesn't try to guess whether an existing port is used by Airbyte or not (since it's now only called when no cluster exists)

Some code-level changes:
- I moved some docker mock test stuff into `dockertest`
- I merged `docker.Port()` into `getPort()` - it was only being called from `getPort` and with it merged, I can easily do the `status == running` check, and the tests seem improved as well.
- `getPort()` now takes a cluster name, instead of the whole `k8s.Provider`

I made these changes to address to scenarios:
1. I have another, unrelated container bound to port 8000
2. I have an abctl cluster that was created but the container has been stopped (e.g. I restarted my Docker Desktop)

These changes improved the experience in these cases:

# Unrelated container bound to port 8000
Before:
<img width="1512" alt="Screenshot 2024-08-30 at 1 29 31 PM" src="https://github.com/user-attachments/assets/fb167668-83af-4bcd-9bb0-c6809782a874">

After:
<img width="768" alt="Screenshot 2024-08-30 at 1 25 06 PM" src="https://github.com/user-attachments/assets/b8a5da53-12d2-4316-bf86-e450370e20ae">

# Cluster in stopped container
Before:
<img width="1512" alt="Screenshot 2024-08-30 at 1 32 56 PM" src="https://github.com/user-attachments/assets/60b6c604-c753-4490-9f9a-28c45eefa0ca">

After:
<img width="641" alt="Screenshot 2024-08-30 at 1 53 43 PM" src="https://github.com/user-attachments/assets/54759456-88c2-402a-aa7d-102bad21e095">

