### PR TITLE
chore: clean-up custom error and help message

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -16,37 +16,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// Help messages to display for specific error situations.
-const (
-	// helpAirbyteDir is displayed if ErrAirbyteDir is ever returned
-	helpAirbyteDir = `The ~/.airbyte directory is inaccessible.
-You may need to remove this directory before trying your command again.`
-
-	// helpCluster is displayed if ErrClusterNotFound is ever returned
-	helpCluster = `No cluster was found. If this is unexpected,
-you may need to run the "local install" command again.`
-
-	// helpDocker is displayed if ErrDocker is ever returned
-	helpDocker = `An error occurred while communicating with the Docker daemon.
-Ensure that Docker is running and is accessible.  You may need to upgrade to a newer version of Docker.
-For additional help please visit https://docs.docker.com/get-docker/`
-
-	// helpKubernetes is displayed if ErrKubernetes is ever returned
-	helpKubernetes = `An error occurred while communicating with the Kubernetes cluster.
-If this error persists, you may need to run the uninstall command before attempting to run
-the install command again.`
-
-	// helpIngress is displayed if ErrIngress is ever returned
-	helpIngress = `An error occurred while configuring ingress.
-This could be in indication that the ingress port is already in use by a different application.
-The ingress port can be changed by passing the flag --port.`
-
-	// helpPort is displayed if ErrPort is ever returned
-	helpPort = `An error occurred while verifying if the request port is available.
-This could be in indication that the ingress port is already in use by a different application.
-The ingress port can be changed by passing the flag --port.`
-)
-
 func HandleErr(err error) {
 	if err == nil {
 		return
@@ -59,25 +28,10 @@ func HandleErr(err error) {
 		_ = kong.DefaultHelpPrinter(kong.HelpOptions{}, errParse.Context)
 	}
 
-	switch {
-	case errors.Is(err, localerr.ErrAirbyteDir):
+	var e *localerr.LocalError
+	if errors.As(err, &e) {
 		pterm.Println()
-		pterm.Info.Println(helpAirbyteDir)
-	case errors.Is(err, localerr.ErrClusterNotFound):
-		pterm.Println()
-		pterm.Info.Println(helpCluster)
-	case errors.Is(err, localerr.ErrDocker):
-		pterm.Println()
-		pterm.Info.Println(helpDocker)
-	case errors.Is(err, localerr.ErrKubernetes):
-		pterm.Println()
-		pterm.Info.Println(helpKubernetes)
-	case errors.Is(err, localerr.ErrIngress):
-		pterm.Println()
-		pterm.Info.Println(helpIngress)
-	case errors.Is(err, localerr.ErrPort):
-		pterm.Println()
-		pterm.Info.Printfln(helpPort)
+		pterm.Info.Println(e.Help())
 	}
 
 	os.Exit(1)

--- a/internal/cmd/local/localerr/localerr.go
+++ b/internal/cmd/local/localerr/localerr.go
@@ -1,23 +1,67 @@
 package localerr
 
-import "errors"
+var _ error = (*LocalError)(nil)
+
+// LocalError adds a user-friendly help message to specific errors.
+type LocalError struct {
+	help string
+	msg  string
+}
+
+// Help will displayed to the user if this specific error is ever returned.
+func (e *LocalError) Help() string {
+	return e.help
+}
+
+// Error returns the error message.
+func (e *LocalError) Error() string {
+	return e.msg
+}
 
 var (
 	// ErrAirbyteDir is returned anytime an there is an issue in accessing the paths.Airbyte directory.
-	ErrAirbyteDir = errors.New("airbyte directory is inaccessible")
+	ErrAirbyteDir = &LocalError{
+		msg: "airbyte directory is inaccessible",
+		help: `The ~/.airbyte directory is inaccessible.
+You may need to remove this directory before trying your command again.`,
+	}
 
 	// ErrClusterNotFound is returned in the event that no cluster was located.
-	ErrClusterNotFound = errors.New("no existing cluster found")
+	ErrClusterNotFound = &LocalError{
+		msg: "no existing cluster found",
+		help: `No cluster was found. If this is unexpected,
+you may need to run the "local install" command again.`,
+	}
 
 	// ErrDocker is returned anytime an error occurs when attempting to communicate with docker.
-	ErrDocker = errors.New("error communicating with docker")
+	ErrDocker = &LocalError{
+		msg: "error communicating with docker",
+		help: `An error occurred while communicating with the Docker daemon.
+Ensure that Docker is running and is accessible.  You may need to upgrade to a newer version of Docker.
+For additional help please visit https://docs.docker.com/get-docker/`,
+	}
 
 	// ErrKubernetes is returned anytime an error occurs when attempting to communicate with the kubernetes cluster.
-	ErrKubernetes = errors.New("error communicating with kubernetes")
+	ErrKubernetes = &LocalError{
+		msg: "error communicating with kubernetes",
+		help: `An error occurred while communicating with the Kubernetes cluster.
+		If this error persists, you may need to run the uninstall command before attempting to run
+		the install command again.`,
+	}
 
 	// ErrIngress is returned in the event that ingress configuration failed.
-	ErrIngress = errors.New("error configuring ingress")
+	ErrIngress = &LocalError{
+		msg: "error configuring ingress",
+		help: `An error occurred while configuring ingress.
+This could be in indication that the ingress port is already in use by a different application.
+The ingress port can be changed by passing the flag --port.`,
+	}
 
 	// ErrPort is returned in the event that the requested port is unavailable.
-	ErrPort = errors.New("error verifying port availability")
+	ErrPort = &LocalError{
+		msg: "error verifying port availability",
+		help: `An error occurred while verifying if the request port is available.
+This could be in indication that the ingress port is already in use by a different application.
+The ingress port can be changed by passing the flag --port.`,
+	}
 )

--- a/internal/cmd/local/localerr/localerr_test.go
+++ b/internal/cmd/local/localerr/localerr_test.go
@@ -1,0 +1,30 @@
+package localerr
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestLocalError(t *testing.T) {
+	f := func() error {
+		return &LocalError{
+			help: "help message",
+			msg:  "error message",
+		}
+	}
+
+	err := f()
+	var e *LocalError
+	if !errors.As(err, &e) {
+		t.Fatal("error should be of type LocalError")
+	}
+
+	if d := cmp.Diff("help message", e.Help()); d != "" {
+		t.Errorf("help message diff:\n%s", d)
+	}
+	if d := cmp.Diff("error message", e.Error()); d != "" {
+		t.Errorf("error message diff:\n%s", d)
+	}
+}


### PR DESCRIPTION
- introduce a `LocalError` type
    - combines an error message with a help message
- migrate all the existing errors with help messages to this type 