### PR TITLE
fix: avoid helm conflict with local directory

### DIFF
--- a/internal/cmd/local/local/cmd_test.go
+++ b/internal/cmd/local/local/cmd_test.go
@@ -26,6 +26,14 @@ import (
 )
 
 const portTest = 9999
+const testAirbyteChartLoc = "https://airbytehq.github.io/helm-charts/airbyte-1.2.3.tgz"
+
+func testChartLocator(chartName, chartVersion string) string {
+	if chartName == airbyteChartName && chartVersion == "" {
+		return testAirbyteChartLoc
+	}
+	return chartName
+}
 
 func TestCommand_Install(t *testing.T) {
 	expChartRepoCnt := 0
@@ -48,7 +56,7 @@ func TestCommand_Install(t *testing.T) {
 		{
 			chart: helmclient.ChartSpec{
 				ReleaseName:     airbyteChartRelease,
-				ChartName:       airbyteChartName,
+				ChartName:       testAirbyteChartLoc,
 				Namespace:       airbyteNamespace,
 				CreateNamespace: true,
 				Wait:            true,
@@ -106,7 +114,7 @@ func TestCommand_Install(t *testing.T) {
 
 		getChart: func(name string, _ *action.ChartPathOptions) (*chart.Chart, string, error) {
 			switch {
-			case name == airbyteChartName:
+			case name == testAirbyteChartLoc:
 				return &chart.Chart{Metadata: &chart.Metadata{Version: "test.airbyte.version"}}, "", nil
 			case name == nginxChartName:
 				return &chart.Chart{Metadata: &chart.Metadata{Version: "test.nginx.version"}}, "", nil
@@ -183,6 +191,7 @@ func TestCommand_Install(t *testing.T) {
 		WithBrowserLauncher(func(url string) error {
 			return nil
 		}),
+		WithChartLocator(testChartLocator),
 	)
 
 	if err != nil {
@@ -215,7 +224,7 @@ func TestCommand_Install_ValuesFile(t *testing.T) {
 		{
 			chart: helmclient.ChartSpec{
 				ReleaseName:     airbyteChartRelease,
-				ChartName:       airbyteChartName,
+				ChartName:       testAirbyteChartLoc,
 				Namespace:       airbyteNamespace,
 				CreateNamespace: true,
 				Wait:            true,
@@ -274,7 +283,7 @@ func TestCommand_Install_ValuesFile(t *testing.T) {
 
 		getChart: func(name string, _ *action.ChartPathOptions) (*chart.Chart, string, error) {
 			switch {
-			case name == airbyteChartName:
+			case name == testAirbyteChartLoc:
 				return &chart.Chart{Metadata: &chart.Metadata{Version: "test.airbyte.version"}}, "", nil
 			case name == nginxChartName:
 				return &chart.Chart{Metadata: &chart.Metadata{Version: "test.nginx.version"}}, "", nil
@@ -351,6 +360,7 @@ func TestCommand_Install_ValuesFile(t *testing.T) {
 		WithBrowserLauncher(func(url string) error {
 			return nil
 		}),
+		WithChartLocator(testChartLocator),
 	)
 
 	if err != nil {

--- a/internal/cmd/local/local/locate.go
+++ b/internal/cmd/local/local/locate.go
@@ -1,0 +1,67 @@
+package local
+
+import (
+	"fmt"
+
+	"github.com/pterm/pterm"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/getter"
+	"helm.sh/helm/v3/pkg/repo"
+)
+
+func locateLatestAirbyteChart(chartName, chartVersion string) string {
+	pterm.Debug.Printf("getting helm chart %q with version %q\n", chartName, chartVersion)
+
+	// Helm will consider a local directory path named "airbyte/airbyte" to be a chart repo,
+	// but it might not be, which causes errors like "Chart.yaml file is missing".
+	// This trips up plenty of people, see: https://github.com/helm/helm/issues/7862
+	//
+	// Here we avoid that problem by figuring out the full URL of the airbyte chart,
+	// which forces Helm to resolve the chart over HTTP and ignore local directories.
+	// If the locator fails, fall back to the original helm behavior.
+	if chartName == airbyteChartName && chartVersion == "" {
+		if url, err := getLatestAirbyteChartUrlFromRepoIndex(airbyteRepoName, airbyteRepoURL); err == nil {
+			pterm.Debug.Printf("determined latest airbyte chart url: %s\n", url)
+			return url
+		} else {
+			pterm.Debug.Printf("error determining latest airbyte chart, falling back to default behavior: %s\n", err)
+		}
+	}
+
+	return chartName
+}
+
+func getLatestAirbyteChartUrlFromRepoIndex(repoName, repoUrl string) (string, error) {
+	chartRepo, err := repo.NewChartRepository(&repo.Entry{
+		Name: repoName,
+		URL:  repoUrl,
+	}, getter.All(cli.New()))
+	if err != nil {
+		return "", fmt.Errorf("unable to access repo index: %w", err)
+	}
+
+	idxPath, err := chartRepo.DownloadIndexFile()
+	if err != nil {
+		return "", fmt.Errorf("unable to access repo index: %w", err)
+	}
+
+	idx, err := repo.LoadIndexFile(idxPath)
+	if err != nil {
+		return "", fmt.Errorf("unable to access repo index: %w", err)
+	}
+
+	airbyteEntry, ok := idx.Entries["airbyte"]
+	if !ok {
+		return "", fmt.Errorf("no entry for airbyte in repo index")
+	}
+
+	if len(airbyteEntry) == 0 {
+		return "", fmt.Errorf("no chart version found")
+	}
+
+	latest := airbyteEntry[0]
+	if len(latest.URLs) != 1 {
+		return "", fmt.Errorf("unexpected number of URLs")
+	}
+	return airbyteRepoURL + "/" + latest.URLs[0], nil
+}

--- a/internal/cmd/local/local/locate.go
+++ b/internal/cmd/local/local/locate.go
@@ -42,12 +42,12 @@ func getLatestAirbyteChartUrlFromRepoIndex(repoName, repoUrl string) (string, er
 
 	idxPath, err := chartRepo.DownloadIndexFile()
 	if err != nil {
-		return "", fmt.Errorf("unable to access repo index: %w", err)
+		return "", fmt.Errorf("unable to download index file: %w", err)
 	}
 
 	idx, err := repo.LoadIndexFile(idxPath)
 	if err != nil {
-		return "", fmt.Errorf("unable to access repo index: %w", err)
+		return "", fmt.Errorf("unable to load index file (%s): %w", idxPath, err)
 	}
 
 	airbyteEntry, ok := idx.Entries["airbyte"]


### PR DESCRIPTION
Helm has an issue where it can confuse a local directory with a requested chart: https://github.com/helm/helm/issues/7862

For example, if you have a local, empty directory path `./airbyte/airbyte` and you request the `airbyte/airbyte` chart, abctl + helm will fail with `unable to install airbyte chart: unable to fetch chart airbyte/airbyte: Chart.yaml file is missing`

This change avoids that problem (currently only for the `airbyte/airbyte` chart when requesting the latest version) by determining the full URL of the chart and using that, which causes Helm to avoid looking at local directories.

I avoided handling the nginx chart and non-latest versions here for simplicity, but I could probably add support for those fairly easily.