### PR TITLE
feat: stream pod logs

### DIFF
--- a/internal/cmd/local/k8s/client.go
+++ b/internal/cmd/local/k8s/client.go
@@ -75,6 +75,7 @@ type Client interface {
 	EventsWatch(ctx context.Context, namespace string) (watch.Interface, error)
 
 	LogsGet(ctx context.Context, namespace string, name string) (string, error)
+	StreamPodLogs(ctx context.Context, namespace string, podName string) (io.ReadCloser, error)
 }
 
 var _ Client = (*DefaultK8sClient)(nil)
@@ -324,4 +325,9 @@ func (d *DefaultK8sClient) LogsGet(ctx context.Context, namespace string, name s
 		return "", fmt.Errorf("unable to copy logs from pod %s: %w", name, err)
 	}
 	return buf.String(), nil
+}
+
+func (d *DefaultK8sClient) StreamPodLogs(ctx context.Context, namespace string, podName string) (io.ReadCloser, error) {
+	req := d.ClientSet.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{Follow: true})
+	return req.Stream(ctx)
 }

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -582,7 +582,7 @@ func (c *Command) streamPodLogsToOutput(ctx context.Context, namespace string, p
 	for scanner.Scan() {
 		pterm.Debug.Println(scanner.Text())
 	}
-	
+
 	pterm.Debug.Printfln("done streaming logs for %s", podName)
 	return nil
 }
@@ -607,7 +607,6 @@ func retry(msg string, maxAttempts int, sleep time.Duration, f func() error) {
 	}
 }
 
-
 // handleEvent converts a kubernetes event into a console log message
 func (c *Command) handleEvent(ctx context.Context, e *eventsv1.Event) {
 	// TODO: replace DeprecatedLastTimestamp,
@@ -617,7 +616,7 @@ func (c *Command) handleEvent(ctx context.Context, e *eventsv1.Event) {
 	}
 
 	if e.Type == "Normal" && e.Reason == "Started" && e.Regarding.Kind == "Pod" {
-		go retry(fmt.Sprintf("streaming pod logs for %q", e.Regarding.Name), 5, 2 * time.Second, func() error {
+		go retry(fmt.Sprintf("streaming pod logs for %q", e.Regarding.Name), 5, 2*time.Second, func() error {
 			return c.streamPodLogsToOutput(ctx, e.Regarding.Namespace, e.Regarding.Name)
 		})
 	}


### PR DESCRIPTION
Stream pod logs so that people can see what's going wrong. For example, if you put in the wrong database password and the bootloader can't connect to the data.

More to do here:
- [ ] consider parsing out log lines, maybe match only error (and warning?) lines by default
- [ ] slim down java stacktrace lines (look for "Caused by..." maybe?)
- [ ] tests
- [ ] code cleanup

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3ae5e5e6-2d4f-439b-b3f8-aaf098d15ec9">

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/32310a87-debd-4d90-92e5-6133eb451df3">
