### PR TITLE
ci: validate release tag name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,12 @@ jobs:
     name: Build and publish release
     runs-on: ubuntu-latest
     steps:
+      - name: Validate tag
+        run: |
+          if [[ ! "${{ inputs.tag_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then 
+              echo "tag is invalid: must be in the form 'v0.0.0'"
+              exit 1
+          fi
       - name: Create tag
         uses: actions/github-script@v5
         with:


### PR DESCRIPTION
Prevent me from creating invalid release tags like `0.14.0`. Release tags need to be like `v0.14.0`