### PR TITLE
fix: clean up helm debug logs

### DIFF
--- a/internal/cmd/local/helm/helm.go
+++ b/internal/cmd/local/helm/helm.go
@@ -68,5 +68,5 @@ func (d helmLogger) Write(p []byte) (int, error) {
 }
 
 func (d helmLogger) Debug(format string, v ...interface{}) {
-	pterm.Debug.Println(fmt.Sprintf("helm - DEBUG: "+format, v...))
+	pterm.Debug.Println(fmt.Sprintf("helm: "+format, v...))
 }


### PR DESCRIPTION
Tiny tweak to remove unnecessary `...-DEBUG...` noise from helm debug logs