### PR TITLE
feat: stream bootloader logs

### DIFF
--- a/internal/cmd/local/k8s/k8stest/k8stest.go
+++ b/internal/cmd/local/k8s/k8stest/k8stest.go
@@ -2,6 +2,8 @@ package k8stest
 
 import (
 	"context"
+	"io"
+	"time"
 
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
 	v1 "k8s.io/api/apps/v1"
@@ -33,6 +35,7 @@ type MockClient struct {
 	FnServiceGet                  func(ctx context.Context, namespace, name string) (*corev1.Service, error)
 	FnEventsWatch                 func(ctx context.Context, namespace string) (watch.Interface, error)
 	FnLogsGet                     func(ctx context.Context, namespace string, name string) (string, error)
+	FnStreamPodLogs               func(ctx context.Context, namespace, podName string, since time.Time) (io.ReadCloser, error)
 }
 
 func (m *MockClient) DeploymentList(ctx context.Context, namespace string) (*v1.DeploymentList, error) {
@@ -165,4 +168,11 @@ func (m *MockClient) LogsGet(ctx context.Context, namespace string, name string)
 		return "LogsGet called", nil
 	}
 	return m.FnLogsGet(ctx, namespace, name)
+}
+
+func (m *MockClient) StreamPodLogs(ctx context.Context, namespace string, podName string, since time.Time) (io.ReadCloser, error) {
+	if m.FnStreamPodLogs == nil {
+		panic("FnStreamPodLogs is not configured")
+	}
+	return m.FnStreamPodLogs(ctx, namespace, podName, since)
 }

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -20,6 +20,7 @@ import (
 )
 
 const (
+	airbyteBootloaderPodName = "airbyte-abctl-airbyte-bootloader"
 	airbyteChartName    = "airbyte/airbyte"
 	airbyteChartRelease = "airbyte-abctl"
 	airbyteIngress      = "ingress-abctl"

--- a/internal/cmd/local/local/install.go
+++ b/internal/cmd/local/local/install.go
@@ -384,7 +384,7 @@ func (c *Command) watchEvents(ctx context.Context) {
 var javaLogRx = regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \x1b\[(?:1;)?\d+m(?P<level>[A-Z]+)\x1b\[m (?P<msg>\S+ - .*)`)
 
 func (c *Command) streamPodLogs(ctx context.Context, namespace, podName, prefix string, since time.Time) error {
-	r, err := c.k8s.StreamPodLogs(ctx, airbyteNamespace, airbyteBootloaderPodName, since)
+	r, err := c.k8s.StreamPodLogs(ctx, namespace, podName, since)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Stream bootloader logs to the debug output, unless they're at the "ERROR" level, then write them as error logs.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/13fe123f-ad8d-43f4-9f10-72ef8e5769ca">
