### PR TITLE
feat: better reporting of airbyte chart errors

### DIFF
--- a/internal/cmd/local/k8s/client.go
+++ b/internal/cmd/local/k8s/client.go
@@ -330,12 +330,12 @@ func (d *DefaultK8sClient) LogsGet(ctx context.Context, namespace string, name s
 
 func (d *DefaultK8sClient) StreamPodLogs(ctx context.Context, namespace string, podName string, since time.Time) (io.ReadCloser, error) {
 	req := d.ClientSet.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
-		Follow: true,
+		Follow:    true,
 		SinceTime: &metav1.Time{Time: since},
 	})
 	return req.Stream(ctx)
 }
 
-func (d *DefaultK8sClient) ListPods(ctx context.Context, namespace string) (*corev1.PodList, error) {
+func (d *DefaultK8sClient) PodList(ctx context.Context, namespace string) (*corev1.PodList, error) {
 	return d.ClientSet.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 }

--- a/internal/cmd/local/k8s/client.go
+++ b/internal/cmd/local/k8s/client.go
@@ -76,7 +76,7 @@ type Client interface {
 
 	LogsGet(ctx context.Context, namespace string, name string) (string, error)
 	StreamPodLogs(ctx context.Context, namespace string, podName string, since time.Time) (io.ReadCloser, error)
-	ListPods(ctx context.Context, namespace string) (*corev1.PodList, error)
+	PodList(ctx context.Context, namespace string) (*corev1.PodList, error)
 }
 
 var _ Client = (*DefaultK8sClient)(nil)

--- a/internal/cmd/local/k8s/k8stest/k8stest.go
+++ b/internal/cmd/local/k8s/k8stest/k8stest.go
@@ -36,6 +36,7 @@ type MockClient struct {
 	FnEventsWatch                 func(ctx context.Context, namespace string) (watch.Interface, error)
 	FnLogsGet                     func(ctx context.Context, namespace string, name string) (string, error)
 	FnStreamPodLogs               func(ctx context.Context, namespace, podName string, since time.Time) (io.ReadCloser, error)
+	FnPodList					  func(ctx context.Context, namespace string) (*corev1.PodList, error)
 }
 
 func (m *MockClient) DeploymentList(ctx context.Context, namespace string) (*v1.DeploymentList, error) {
@@ -175,4 +176,11 @@ func (m *MockClient) StreamPodLogs(ctx context.Context, namespace string, podNam
 		panic("FnStreamPodLogs is not configured")
 	}
 	return m.FnStreamPodLogs(ctx, namespace, podName, since)
+}
+
+func (m *MockClient) PodList(ctx context.Context, namespace string) (*corev1.PodList, error) {
+	if m.FnPodList == nil {
+		return nil, nil
+	}
+	return m.FnPodList(ctx, namespace)
 }

--- a/internal/cmd/local/local/install.go
+++ b/internal/cmd/local/local/install.go
@@ -330,7 +330,7 @@ func (c *Command) Install(ctx context.Context, opts InstallOpts) error {
 
 func (c *Command) diagnoseAirbyteChartFailure(ctx context.Context, chartErr error) error {
 
-	if podList, err := c.k8s.ListPods(ctx, airbyteNamespace); err == nil {
+	if podList, err := c.k8s.PodList(ctx, airbyteNamespace); err == nil {
 
 		errors := []string{}
 		for _, pod := range podList.Items {

--- a/internal/cmd/local/local/install.go
+++ b/internal/cmd/local/local/install.go
@@ -341,7 +341,7 @@ func (c *Command) diagnoseAirbyteChartFailure(ctx context.Context, chartErr erro
 				if err != nil {
 					msg = "unknown: failed to get pod logs."
 				}
-				m, err := getLastJavaLogError(strings.NewReader(logs))
+				m, err := getLastLogError(strings.NewReader(logs))
 				if err != nil {
 					msg = "unknown: failed to find error log."
 				}
@@ -413,7 +413,7 @@ func (c *Command) streamPodLogs(ctx context.Context, namespace, podName, prefix 
 	}
 	defer r.Close()
 
-	s := newJavaLogScanner(r)
+	s := newLogScanner(r)
 	for s.Scan() {
 		if s.line.level == "ERROR" {
 			pterm.Error.Printfln("%s: %s", prefix, s.line.msg)

--- a/internal/cmd/local/local/install.go
+++ b/internal/cmd/local/local/install.go
@@ -3,7 +3,6 @@ package local
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -161,7 +160,6 @@ func (c *Command) Install(ctx context.Context, opts InstallOpts) error {
 
 	if opts.Migrate {
 		c.spinner.UpdateText("Migrating airbyte data")
-		//if err := c.tel.Wrap(ctx, telemetry.Migrate, func() error { return opts.Docker.MigrateComposeDB(ctx, "airbyte_db") }); err != nil {
 		if err := c.tel.Wrap(ctx, telemetry.Migrate, func() error { return migrate.FromDockerVolume(ctx, opts.Docker.Client, "airbyte_db") }); err != nil {
 			pterm.Error.Println("Failed to migrate data from previous Airbyte installation")
 			return fmt.Errorf("unable to migrate data from previous airbyte installation: %w", err)

--- a/internal/cmd/local/local/install.go
+++ b/internal/cmd/local/local/install.go
@@ -1,13 +1,12 @@
 package local
 
 import (
-	"bufio"
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -275,7 +274,7 @@ func (c *Command) Install(ctx context.Context, opts InstallOpts) error {
 		namespace:    airbyteNamespace,
 		valuesYAML:   valuesYAML,
 	}); err != nil {
-		return fmt.Errorf("unable to install airbyte chart: %w", err)
+		return c.diagnoseAirbyteChartFailure(ctx, err)
 	}
 
 	if err := c.handleChart(ctx, chartRequest{
@@ -331,6 +330,35 @@ func (c *Command) Install(ctx context.Context, opts InstallOpts) error {
 	return nil
 }
 
+func (c *Command) diagnoseAirbyteChartFailure(ctx context.Context, chartErr error) error {
+
+	if podList, err := c.k8s.ListPods(ctx, airbyteNamespace); err == nil {
+
+		errors := []string{}
+		for _, pod := range podList.Items {
+			if pod.Status.Phase == corev1.PodFailed {
+				msg := "unknown"
+
+				logs, err := c.k8s.LogsGet(ctx, airbyteNamespace, pod.Name)
+				if err != nil {
+					msg = "unknown: failed to get pod logs."
+				}
+				m, err := getLastJavaLogError(strings.NewReader(logs))
+				if err != nil {
+					msg = "unknown: failed to find error log."
+				}
+				if m != "" {
+					msg = m
+				}
+
+				errors = append(errors, fmt.Sprintf("pod %s: %s", pod.Name, msg))
+			}
+		}
+		return fmt.Errorf("unable to install airbyte chart:\n%s", strings.Join(errors, "\n"))
+	}
+	return fmt.Errorf("unable to install airbyte chart: %w", chartErr)
+}
+
 func (c *Command) handleIngress(ctx context.Context, hosts []string) error {
 	c.spinner.UpdateText("Checking for existing Ingress")
 
@@ -380,9 +408,6 @@ func (c *Command) watchEvents(ctx context.Context) {
 	}
 }
 
-// 2024-09-10 20:16:24 WARN i.m.s.r.u.Loggers$Slf4JLogger(warn):299 - [273....
-var javaLogRx = regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \x1b\[(?:1;)?\d+m(?P<level>[A-Z]+)\x1b\[m (?P<msg>\S+ - .*)`)
-
 func (c *Command) streamPodLogs(ctx context.Context, namespace, podName, prefix string, since time.Time) error {
 	r, err := c.k8s.StreamPodLogs(ctx, namespace, podName, since)
 	if err != nil {
@@ -390,33 +415,16 @@ func (c *Command) streamPodLogs(ctx context.Context, namespace, podName, prefix 
 	}
 	defer r.Close()
 
-	level := pterm.Debug
-	scanner := bufio.NewScanner(r)
-
-	for scanner.Scan() {
-
-		// skip java stacktrace noise
-		if strings.HasPrefix(scanner.Text(), "\tat ") || strings.HasPrefix(scanner.Text(), "\t... ") {
-			continue
-		}
-
-		m := javaLogRx.FindSubmatch(scanner.Bytes())
-		var msg string
-
-		if m != nil {
-			msg = string(m[2])
-			if string(m[1]) == "ERROR" {
-				level = pterm.Error
-			} else {
-				level = pterm.Debug
-			}
+	s := newJavaLogScanner(r)
+	for s.Scan() {
+		if s.line.level == "ERROR" {
+			pterm.Error.Printfln("%s: %s", prefix, s.line.msg)
 		} else {
-			msg = scanner.Text()
+			pterm.Debug.Printfln("%s: %s", prefix, s.line.msg)
 		}
-
-		level.Printfln("%s: %s", prefix, msg)
 	}
-	return scanner.Err()
+
+	return s.Err()
 }
 
 func (c *Command) watchBootloaderLogs(ctx context.Context) {

--- a/internal/cmd/local/local/java_logs.go
+++ b/internal/cmd/local/local/java_logs.go
@@ -1,0 +1,80 @@
+package local
+
+import (
+	"bufio"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// 2024-09-10 20:16:24 WARN i.m.s.r.u.Loggers$Slf4JLogger(warn):299 - [273....
+var javaLogRx = regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \x1b\[(?:1;)?\d+m(?P<level>[A-Z]+)\x1b\[m (?P<msg>\S+ - .*)`)
+
+type javaLogLine struct {
+	msg   string
+	level string
+}
+
+type javaLogScanner struct {
+	scanner *bufio.Scanner
+	line    javaLogLine
+}
+
+func newJavaLogScanner(r io.Reader) *javaLogScanner {
+	return &javaLogScanner{
+		scanner: bufio.NewScanner(r),
+		line: javaLogLine{
+			msg:   "",
+			level: "DEBUG",
+		},
+	}
+}
+
+func (j *javaLogScanner) Scan() bool {
+	for {
+		if ok := j.scanner.Scan(); !ok {
+			return false
+		}
+
+		// skip java stacktrace noise
+		if strings.HasPrefix(j.scanner.Text(), "\tat ") || strings.HasPrefix(j.scanner.Text(), "\t... ") {
+			continue
+		}
+
+		m := javaLogRx.FindSubmatch(j.scanner.Bytes())
+
+		if m != nil {
+			j.line.msg = string(m[2])
+			j.line.level = string(m[1])
+		} else {
+			j.line.msg = j.scanner.Text()
+		}
+		return true
+	}
+}
+
+func (j *javaLogScanner) Err() error {
+	return j.scanner.Err()
+}
+
+func getAllJavaLogLines(r io.Reader) ([]javaLogLine, error) {
+	lines := []javaLogLine{}
+	s := newJavaLogScanner(r)
+	for s.Scan() {
+		lines = append(lines, s.line)
+	}
+	return lines, s.Err()
+}
+
+func getLastJavaLogError(r io.Reader) (string, error) {
+	lines, err := getAllJavaLogLines(r)
+	if err != nil {
+		return "", err
+	}
+	for i := len(lines) - 1; i >= 0; i-- {
+		if lines[i].level == "ERROR" {
+			return lines[i].msg, nil
+		}
+	}
+	return "", nil
+}

--- a/internal/cmd/local/local/log_utils.go
+++ b/internal/cmd/local/local/log_utils.go
@@ -8,29 +8,29 @@ import (
 )
 
 // 2024-09-10 20:16:24 WARN i.m.s.r.u.Loggers$Slf4JLogger(warn):299 - [273....
-var javaLogRx = regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \x1b\[(?:1;)?\d+m(?P<level>[A-Z]+)\x1b\[m (?P<msg>\S+ - .*)`)
+var logRx = regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \x1b\[(?:1;)?\d+m(?P<level>[A-Z]+)\x1b\[m (?P<msg>\S+ - .*)`)
 
-type javaLogLine struct {
+type logLine struct {
 	msg   string
 	level string
 }
 
-type javaLogScanner struct {
+type logScanner struct {
 	scanner *bufio.Scanner
-	line    javaLogLine
+	line    logLine
 }
 
-func newJavaLogScanner(r io.Reader) *javaLogScanner {
-	return &javaLogScanner{
+func newLogScanner(r io.Reader) *logScanner {
+	return &logScanner{
 		scanner: bufio.NewScanner(r),
-		line: javaLogLine{
+		line: logLine{
 			msg:   "",
 			level: "DEBUG",
 		},
 	}
 }
 
-func (j *javaLogScanner) Scan() bool {
+func (j *logScanner) Scan() bool {
 	for {
 		if ok := j.scanner.Scan(); !ok {
 			return false
@@ -41,36 +41,35 @@ func (j *javaLogScanner) Scan() bool {
 			continue
 		}
 
-		m := javaLogRx.FindSubmatch(j.scanner.Bytes())
+		m := logRx.FindSubmatch(j.scanner.Bytes())
 
 		if m != nil {
 			j.line.msg = string(m[2])
 			j.line.level = string(m[1])
 		} else {
+			// Some logs aren't from java (e.g. temporal) or they have a different format,
+			// or the log covers multiple lines (e.g. java stack trace). In that case, use the full line
+			// and reuse the level of the previous line.
 			j.line.msg = j.scanner.Text()
 		}
 		return true
 	}
 }
 
-func (j *javaLogScanner) Err() error {
+func (j *logScanner) Err() error {
 	return j.scanner.Err()
 }
 
-func getAllJavaLogLines(r io.Reader) ([]javaLogLine, error) {
-	lines := []javaLogLine{}
-	s := newJavaLogScanner(r)
+func getLastLogError(r io.Reader) (string, error) {
+	lines := []logLine{}
+	s := newLogScanner(r)
 	for s.Scan() {
 		lines = append(lines, s.line)
 	}
-	return lines, s.Err()
-}
-
-func getLastJavaLogError(r io.Reader) (string, error) {
-	lines, err := getAllJavaLogLines(r)
-	if err != nil {
-		return "", err
+	if s.Err() != nil {
+		return "", s.Err()
 	}
+
 	for i := len(lines) - 1; i >= 0; i-- {
 		if lines[i].level == "ERROR" {
 			return lines[i].msg, nil

--- a/internal/cmd/local/local/log_utils_test.go
+++ b/internal/cmd/local/local/log_utils_test.go
@@ -1,0 +1,62 @@
+package local
+
+import (
+	"strings"
+	"testing"
+)
+
+var testLogs = strings.TrimSpace(`
+2024-09-12 15:56:25 [32mINFO[m i.a.d.c.DatabaseAvailabilityCheck(check):49 - Database is not ready yet. Please wait a moment, it might still be initializing...
+2024-09-12 15:56:30 [33mWARN[m i.m.s.r.u.Loggers$Slf4JLogger(warn):299 - [54bd6014, L:/127.0.0.1:52991 - R:localhost/127.0.0.1:8125] An exception has been observed post termination, use DEBUG level to see the full stack: java.net.PortUnreachableException: recvAddress(..) failed: Connection refused
+2024-09-12 15:56:31 [1;31mERROR[m i.a.b.Application(main):25 - Unable to bootstrap Airbyte environment.
+io.airbyte.db.init.DatabaseInitializationException: Database availability check failed.
+	at io.airbyte.db.init.DatabaseInitializer.initialize(DatabaseInitializer.java:54) ~[io.airbyte.airbyte-db-db-lib-0.64.3.jar:?]
+	at io.airbyte.bootloader.Bootloader.initializeDatabases(Bootloader.java:229) ~[io.airbyte-airbyte-bootloader-0.64.3.jar:?]
+	at io.airbyte.bootloader.Bootloader.load(Bootloader.java:104) ~[io.airbyte-airbyte-bootloader-0.64.3.jar:?]
+	at io.airbyte.bootloader.Application.main(Application.java:22) [io.airbyte-airbyte-bootloader-0.64.3.jar:?]
+Caused by: io.airbyte.db.check.DatabaseCheckException: Unable to connect to the database.
+	at io.airbyte.db.check.DatabaseAvailabilityCheck.check(DatabaseAvailabilityCheck.java:40) ~[io.airbyte.airbyte-db-db-lib-0.64.3.jar:?]
+	at io.airbyte.db.init.DatabaseInitializer.initialize(DatabaseInitializer.java:45) ~[io.airbyte.airbyte-db-db-lib-0.64.3.jar:?]
+	... 3 more
+2024-09-12 15:56:31 [32mINFO[m i.m.r.Micronaut(lambda$start$0):118 - Embedded Application shutting down
+2024-09-12T15:56:33.125352208Z Thread-4 INFO Loading mask data from '/seed/specs_secrets_mask.yaml
+`)
+
+func TestJavaLogScanner(t *testing.T) {
+	s := newLogScanner(strings.NewReader(testLogs))
+
+	expectLogLine := func(level, msg string) {
+		s.Scan()
+	
+		if s.line.level != level {
+			t.Errorf("expected level %q but got %q", level, s.line.level)
+		}
+		if s.line.msg != msg {
+			t.Errorf("expected msg %q but got %q", msg, s.line.msg)
+		}
+		if s.Err() != nil {
+			t.Errorf("unexpected error %v", s.Err())
+		}
+	}
+
+	expectLogLine("INFO", "i.a.d.c.DatabaseAvailabilityCheck(check):49 - Database is not ready yet. Please wait a moment, it might still be initializing...")
+	expectLogLine("WARN", "i.m.s.r.u.Loggers$Slf4JLogger(warn):299 - [54bd6014, L:/127.0.0.1:52991 - R:localhost/127.0.0.1:8125] An exception has been observed post termination, use DEBUG level to see the full stack: java.net.PortUnreachableException: recvAddress(..) failed: Connection refused")
+	expectLogLine("ERROR", "i.a.b.Application(main):25 - Unable to bootstrap Airbyte environment.")
+	expectLogLine("ERROR", "io.airbyte.db.init.DatabaseInitializationException: Database availability check failed.")
+	expectLogLine("ERROR", "Caused by: io.airbyte.db.check.DatabaseCheckException: Unable to connect to the database.")
+	expectLogLine("INFO", "i.m.r.Micronaut(lambda$start$0):118 - Embedded Application shutting down")
+	expectLogLine("INFO", "2024-09-12T15:56:33.125352208Z Thread-4 INFO Loading mask data from '/seed/specs_secrets_mask.yaml")
+}
+
+func TestLastErrorLog(t *testing.T) {
+	l, err := getLastLogError(strings.NewReader(testLogs))
+	if err != nil {
+		t.Errorf("unexpected error %s", err)
+	}
+	expect := "Caused by: io.airbyte.db.check.DatabaseCheckException: Unable to connect to the database."
+	if l != expect {
+		t.Errorf("expected %q but got %q", expect, l)
+	}
+}
+
+


### PR DESCRIPTION
This should give us a better error in the telemetry when, for example, the bootloader fails.

Before:
```
unable to install airbyte chart: unable to install helm: failed pre-install: 1 error occurred:
         * pod airbyte-abctl-airbyte-bootloader failed
```

After:
```
 unable to install airbyte chart:
          pod airbyte-abctl-airbyte-bootloader: Caused by: io.airbyte.db.check.DatabaseCheckException: Unable to connect to the database.
```