### PR TITLE
fix: use k8s yaml lib

### DIFF
--- a/internal/cmd/local/local/install.go
+++ b/internal/cmd/local/local/install.go
@@ -23,7 +23,6 @@ import (
 	helmclient "github.com/mittwald/go-helm-client"
 	"github.com/mittwald/go-helm-client/values"
 	"github.com/pterm/pterm"
-	"gopkg.in/yaml.v2"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
@@ -31,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 const (


### PR DESCRIPTION
In the previous pull request https://github.com/airbytehq/abctl/pull/103, it seems the YAML package was changed from `"k8s.io/apimachinery/pkg/util/yaml"` to `"gopkg.in/yaml.v2"`. This change is causing issues when people try to use `abctl` with `secrets.yaml`. During the parsing operation, the `metadata.name` property of the secret is not parsed properly.

Proposal is to return to previous package but maybe we can work to get to fix the unmarshall step using the new package.