### PR TITLE
fix: remove dynamic telemetry attr

### DIFF
--- a/internal/cmd/local/local/install.go
+++ b/internal/cmd/local/local/install.go
@@ -318,9 +318,6 @@ func (c *Command) diagnoseAirbyteChartFailure(ctx context.Context, chartErr erro
 
 		var errors []string
 		for _, pod := range podList.Items {
-			c.tel.Attr("pod-name", pod.Name)
-			c.tel.Attr("pod-phase", string(pod.Status.Phase))
-
 			if pod.Status.Phase == corev1.PodFailed {
 				msg := "unknown"
 

--- a/internal/cmd/local/local/install.go
+++ b/internal/cmd/local/local/install.go
@@ -318,8 +318,9 @@ func (c *Command) diagnoseAirbyteChartFailure(ctx context.Context, chartErr erro
 
 		var errors []string
 		for _, pod := range podList.Items {
-			c.tel.Attr(fmt.Sprintf("pod-%s-phase", pod.Name), string(pod.Status.Phase))
-			
+			c.tel.Attr("pod-name", pod.Name)
+			c.tel.Attr("pod-phase", string(pod.Status.Phase))
+
 			if pod.Status.Phase == corev1.PodFailed {
 				msg := "unknown"
 


### PR DESCRIPTION
- dynamic attribute names cause issues with our telemetry tracking
    - removing this attribute for now, will need to revisit how to capture this data