### PR TITLE
fix: set JOB_MAIN_CONTAINER envs in low-resource-mode

### DIFF
--- a/internal/cmd/local/local/install.go
+++ b/internal/cmd/local/local/install.go
@@ -196,6 +196,8 @@ func (c *Command) Install(ctx context.Context, opts InstallOpts) error {
 			"workload-launcher.env_vars.CHECK_JOB_MAIN_CONTAINER_MEMORY_REQUEST=0",
 			"workload-launcher.env_vars.DISCOVER_JOB_MAIN_CONTAINER_CPU_REQUEST=0",
 			"workload-launcher.env_vars.DISCOVER_JOB_MAIN_CONTAINER_MEMORY_REQUEST=0",
+			"workload-launcher.env_vars.JOB_MAIN_CONTAINER_CPU_REQUEST=0",
+			"workload-launcher.env_vars.JOB_MAIN_CONTAINER_MEMORY_REQUEST=0",
 			"workload-launcher.env_vars.SPEC_JOB_MAIN_CONTAINER_CPU_REQUEST=0",
 			"workload-launcher.env_vars.SPEC_JOB_MAIN_CONTAINER_MEMORY_REQUEST=0",
 			"workload-launcher.env_vars.SIDECAR_MAIN_CONTAINER_CPU_REQUEST=0",


### PR DESCRIPTION
- set the following env-vars to `0` when running in `low-resource-mode`
    - `JOB_MAIN_CONTAINER_CPU_REQUEST`
    - `JOB_MAIN_CONTAINER_MEMORY_REQUEST`