### PR TITLE
feat: --chart flag

### DIFF
--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -45,7 +45,7 @@ type HTTPClient interface {
 type BrowserLauncher func(url string) error
 
 // ChartLocator primarily for testing purposes.
-type ChartLocator func(repoName, repoUrl string) string
+type ChartLocator func(repoName, repoUrl, chartFlag string) string
 
 // Command is the local command, responsible for installing, uninstalling, or other local actions.
 type Command struct {

--- a/internal/cmd/local/local/install.go
+++ b/internal/cmd/local/local/install.go
@@ -42,6 +42,7 @@ const (
 )
 
 type InstallOpts struct {
+	HelmChartFlag     string
 	HelmChartVersion string
 	ValuesFile       string
 	Secrets          []string
@@ -252,6 +253,7 @@ func (c *Command) Install(ctx context.Context, opts InstallOpts) error {
 		repoURL:      airbyteRepoURL,
 		chartName:    airbyteChartName,
 		chartRelease: airbyteChartRelease,
+		chartFlag:    opts.HelmChartFlag,
 		chartVersion: opts.HelmChartVersion,
 		namespace:    airbyteNamespace,
 		valuesYAML:   valuesYAML,
@@ -524,6 +526,7 @@ type chartRequest struct {
 	repoURL        string
 	chartName      string
 	chartRelease   string
+	chartFlag      string
 	chartVersion   string
 	namespace      string
 	values         []string
@@ -548,7 +551,7 @@ func (c *Command) handleChart(
 
 	c.spinner.UpdateText(fmt.Sprintf("Fetching %s Helm Chart with version", req.chartName))
 
-	chartLoc := c.locateChart(req.chartName, req.chartVersion)
+	chartLoc := c.locateChart(req.chartName, req.chartVersion, req.chartFlag)
 
 	helmChart, _, err := c.helm.GetChart(chartLoc, &action.ChartPathOptions{Version: req.chartVersion})
 	if err != nil {

--- a/internal/cmd/local/local/install_test.go
+++ b/internal/cmd/local/local/install_test.go
@@ -26,7 +26,7 @@ import (
 const portTest = 9999
 const testAirbyteChartLoc = "https://airbytehq.github.io/helm-charts/airbyte-1.2.3.tgz"
 
-func testChartLocator(chartName, chartVersion string) string {
+func testChartLocator(chartName, chartVersion, chartFlag string) string {
 	if chartName == airbyteChartName && chartVersion == "" {
 		return testAirbyteChartLoc
 	}
@@ -396,5 +396,4 @@ func TestCommand_Install_InvalidValuesFile(t *testing.T) {
 	if !strings.Contains(err.Error(), fmt.Sprintf("unable to read values from yaml file '%s'", valuesFile)) {
 		t.Error("unexpected error:", err)
 	}
-
 }

--- a/internal/cmd/local/local/locate.go
+++ b/internal/cmd/local/local/locate.go
@@ -9,8 +9,13 @@ import (
 	"helm.sh/helm/v3/pkg/repo"
 )
 
-func locateLatestAirbyteChart(chartName, chartVersion string) string {
+func locateLatestAirbyteChart(chartName, chartVersion, chartFlag string) string {
 	pterm.Debug.Printf("getting helm chart %q with version %q\n", chartName, chartVersion)
+
+	// If the --chart flag was given, use that.
+	if chartFlag != "" {
+		return chartFlag
+	}
 
 	// Helm will consider a local directory path named "airbyte/airbyte" to be a chart repo,
 	// but it might not be, which causes errors like "Chart.yaml file is missing".

--- a/internal/cmd/local/local/locate_test.go
+++ b/internal/cmd/local/local/locate_test.go
@@ -1,0 +1,11 @@
+package local
+
+import "testing"
+
+func TestLocateChartFlag(t *testing.T) {
+	expect := "chartFlagValue"
+	c := locateLatestAirbyteChart("airbyte", "", expect)
+	if c != expect {
+		t.Errorf("expected %q but got %q", expect, c)
+	}
+}

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -12,6 +12,7 @@ import (
 )
 
 type InstallCmd struct {
+	Chart           string   `help:"Path to chart."`
 	ChartVersion    string   `default:"latest" help:"Version to install."`
 	DockerEmail     string   `group:"docker" help:"Docker email." env:"ABCTL_LOCAL_INSTALL_DOCKER_EMAIL"`
 	DockerPassword  string   `group:"docker" help:"Docker password." env:"ABCTL_LOCAL_INSTALL_DOCKER_PASSWORD"`
@@ -101,6 +102,7 @@ func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient t
 		}
 
 		opts := local.InstallOpts{
+			HelmChartFlag:        i.Chart,
 			HelmChartVersion: i.ChartVersion,
 			ValuesFile:       i.Values,
 			Secrets:          i.Secret,


### PR DESCRIPTION
`--chart` allows using a specific chart, such as a local chart directory (`--chart /Users/alexbuchanan/dev/dev-chart`)

I've been hacking a local chart path into my abctl code to do development with a local chart directory.