### PR TITLE
feat: validate --host flag for IP address

### DIFF
--- a/internal/cmd/local/check.go
+++ b/internal/cmd/local/check.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"regexp"
 	"runtime"
 	"strconv"
 	"syscall"
@@ -164,4 +165,14 @@ func (e InvalidPortError) Unwrap() error {
 }
 func (e InvalidPortError) Error() string {
 	return fmt.Sprintf("unable to convert host port %s to integer: %s", e.Port, e.Inner)
+}
+
+func validateHostFlag(host string) error {
+	if ip := net.ParseIP(host); ip != nil {
+		return localerr.ErrIpAddressForHostFlag
+	}
+	if !regexp.MustCompile(`^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)*$`).MatchString(host) {
+		return localerr.ErrInvalidHostFlag
+	}
+	return nil
 }

--- a/internal/cmd/local/check_test.go
+++ b/internal/cmd/local/check_test.go
@@ -272,6 +272,31 @@ func TestGetPort_InpsectErr(t *testing.T) {
 	}
 }
 
+func TestValidateHostFlag(t *testing.T) {
+	expectErr := func(host string, expect error) {
+		err := validateHostFlag(host)
+		if !errors.Is(err, expect) {
+			t.Errorf("expected error %v for host %q but got %v", expect, host, err)
+		}
+	}
+	expectErr("1.2.3.4", localerr.ErrIpAddressForHostFlag)
+	expectErr("1.2.3.4:8000", localerr.ErrInvalidHostFlag)
+	expectErr("1.2.3.4:8000", localerr.ErrInvalidHostFlag)
+	expectErr("ABC-DEF-GHI.abcd.efgh", localerr.ErrInvalidHostFlag)
+	expectErr("http://airbyte.foo-data-platform-sbx.bar.cloud", localerr.ErrInvalidHostFlag)
+
+	expectOk := func(host string) {
+		err := validateHostFlag(host)
+		if err != nil {
+			t.Errorf("unexpected error for host %q: %s", host, err)
+		}
+	}
+	expectOk("foo")
+	expectOk("foo.bar")
+	expectOk("example.com")
+	expectOk("sub.example01.com")
+}
+
 // port returns the port from a string value in the format of "ipv4:port" or "ip::v6:port"
 func port(s string) int {
 	vals := strings.Split(s, ":")

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -3,13 +3,12 @@ package local
 import (
 	"context"
 	"fmt"
-	"net"
 	"strings"
 
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
 	"github.com/airbytehq/abctl/internal/cmd/local/local"
-	"github.com/airbytehq/abctl/internal/cmd/local/localerr"
 	"github.com/airbytehq/abctl/internal/maps"
+
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/pterm/pterm"
 )
@@ -53,8 +52,8 @@ func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient t
 	}
 
 	for _, host := range i.Host {
-		if ip := net.ParseIP(host); ip != nil {
-			return localerr.ErrIpAddressForHostFlag
+		if err := validateHostFlag(host); err != nil {
+			return err
 		}
 	}
 

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -3,7 +3,7 @@ package local
 import (
 	"context"
 	"fmt"
-	"regexp"
+	"net"
 	"strings"
 
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
@@ -53,7 +53,7 @@ func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient t
 	}
 
 	for _, host := range i.Host {
-		if regexp.MustCompile(`\d+\.\d+\.\d+\.\d+`).MatchString(host) {
+		if ip := net.ParseIP(host); ip != nil {
 			return localerr.ErrIpAddressForHostFlag
 		}
 	}

--- a/internal/cmd/local/local_test.go
+++ b/internal/cmd/local/local_test.go
@@ -135,10 +135,18 @@ foo:
 	}
 }
 
-func TestInvalidHostFlag(t *testing.T) {
+func TestInvalidHostFlag_IpAddr(t *testing.T) {
 	cmd := InstallCmd{Host: []string{"ok", "1.2.3.4"}}
 	err := cmd.Run(context.Background(), k8s.TestProvider, telemetry.NoopClient{})
 	if !errors.Is(err, localerr.ErrIpAddressForHostFlag) {
 		t.Errorf("expected ErrIpAddressForHostFlag but got %v", err)
+	}
+}
+
+func TestInvalidHostFlag_IpAddrWithPort(t *testing.T) {
+	cmd := InstallCmd{Host: []string{"ok", "1.2.3.4:8000"}}
+	err := cmd.Run(context.Background(), k8s.TestProvider, telemetry.NoopClient{})
+	if !errors.Is(err, localerr.ErrInvalidHostFlag) {
+		t.Errorf("expected ErrInvalidHostFlag but got %v", err)
 	}
 }

--- a/internal/cmd/local/local_test.go
+++ b/internal/cmd/local/local_test.go
@@ -2,12 +2,16 @@ package local
 
 import (
 	"context"
+	"errors"
+
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
+	"github.com/airbytehq/abctl/internal/cmd/local/localerr"
+
 	"github.com/airbytehq/abctl/internal/cmd/local/paths"
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/google/go-cmp/cmp"
@@ -127,5 +131,14 @@ foo:
 
 	if !strings.HasPrefix(err.Error(), "failed to unmarshal file") {
 		t.Errorf("unexpected error: %v", err)
+
+	}
+}
+
+func TestInvalidHostFlag(t *testing.T) {
+	cmd := InstallCmd{Host: []string{"ok", "1.2.3.4"}}
+	err := cmd.Run(context.Background(), k8s.TestProvider, telemetry.NoopClient{})
+	if !errors.Is(err, localerr.ErrIpAddressForHostFlag) {
+		t.Errorf("expected ErrIpAddressForHostFlag but got %v", err)
 	}
 }

--- a/internal/cmd/local/localerr/localerr.go
+++ b/internal/cmd/local/localerr/localerr.go
@@ -64,4 +64,11 @@ The ingress port can be changed by passing the flag --port.`,
 This could be in indication that the ingress port is already in use by a different application.
 The ingress port can be changed by passing the flag --port.`,
 	}
+
+	ErrIpAddressForHostFlag = &LocalError{
+		msg: "invalid host - can't use an IP address",
+		help: `Looks like you provided an IP address to the --host flag.
+This won't work. K8s ingress rules require a DNS-style name.
+By default, abctl will allow access from any hostname or IP, so you might not need the --host flag.`,
+	}
 )

--- a/internal/cmd/local/localerr/localerr.go
+++ b/internal/cmd/local/localerr/localerr.go
@@ -68,7 +68,16 @@ The ingress port can be changed by passing the flag --port.`,
 	ErrIpAddressForHostFlag = &LocalError{
 		msg: "invalid host - can't use an IP address",
 		help: `Looks like you provided an IP address to the --host flag.
-This won't work. K8s ingress rules require a DNS-style name.
+This won't work, because Kubernetes ingress rules require a lowercase domain name.
+
+By default, abctl will allow access from any hostname or IP, so you might not need the --host flag.`,
+	}
+
+	ErrInvalidHostFlag = &LocalError{
+		msg: "invalid host",
+		help: `The --host flag expects a lowercase domain name, e.g. "example.com". 
+IP addresses won't work. Ports won't work (e.g. example:8000). URLs won't work (e.g. http://example.com).
+
 By default, abctl will allow access from any hostname or IP, so you might not need the --host flag.`,
 	}
 )


### PR DESCRIPTION
<img width="782" alt="image" src="https://github.com/user-attachments/assets/1709b63b-0d0e-4baf-a217-99f2afcbf056">

Since this validation happens before the `telemetry.Wrap` call, this should eliminate this category of errors from our error tracking.