### PR TITLE
fix: validate values file yaml early

### DIFF
--- a/internal/cmd/local/local/install_test.go
+++ b/internal/cmd/local/local/install_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -201,7 +200,7 @@ func TestCommand_Install(t *testing.T) {
 	}
 }
 
-func TestCommand_Install_ValuesFile(t *testing.T) {
+func TestCommand_Install_HelmValues(t *testing.T) {
 	expChartRepoCnt := 0
 	expChartRepo := []struct {
 		name string
@@ -365,36 +364,12 @@ func TestCommand_Install_ValuesFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := c.Install(context.Background(), InstallOpts{ValuesFile: "testdata/values.yml"}); err != nil {
+	helmValues := map[string]any{
+		"global": map[string]any{
+			"edition": "test",
+		},
+	}
+	if err := c.Install(context.Background(), InstallOpts{HelmValues: helmValues}); err != nil {
 		t.Fatal(err)
 	}
-}
-
-func TestCommand_Install_InvalidValuesFile(t *testing.T) {
-	c, err := New(
-		k8s.TestProvider,
-		WithPortHTTP(portTest),
-		WithHelmClient(&mockHelmClient{}),
-		WithK8sClient(&k8stest.MockClient{}),
-		WithTelemetryClient(&mockTelemetryClient{}),
-		WithHTTPClient(&mockHTTP{}),
-		WithBrowserLauncher(func(url string) error {
-			return nil
-		}),
-	)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	valuesFile := "testdata/dne.yml"
-
-	err = c.Install(context.Background(), InstallOpts{ValuesFile: valuesFile})
-	if err == nil {
-		t.Fatal("expecting an error, received none")
-	}
-	if !strings.Contains(err.Error(), fmt.Sprintf("unable to read values from yaml file '%s'", valuesFile)) {
-		t.Error("unexpected error:", err)
-	}
-
 }

--- a/internal/cmd/local/local/testdata/values.yml
+++ b/internal/cmd/local/local/testdata/values.yml
@@ -1,2 +1,0 @@
-global:
-  edition: "test"

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
 	"github.com/airbytehq/abctl/internal/cmd/local/local"
+	"github.com/airbytehq/abctl/internal/maps"
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/pterm/pterm"
 )
@@ -37,6 +38,11 @@ func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient t
 	if err != nil {
 		pterm.Error.Println("Unable to determine if Docker is installed")
 		return fmt.Errorf("unable to determine docker installation status: %w", err)
+	}
+
+	helmValues, err := maps.FromYAMLFile(i.Values)
+	if err != nil {
+		return err
 	}
 
 	return telClient.Wrap(ctx, telemetry.Install, func() error {
@@ -102,7 +108,7 @@ func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient t
 
 		opts := local.InstallOpts{
 			HelmChartVersion: i.ChartVersion,
-			ValuesFile:       i.Values,
+			HelmValues:       helmValues,
 			Secrets:          i.Secret,
 			Migrate:          i.Migrate,
 			Docker:           dockerClient,

--- a/internal/cmd/local/local_test.go
+++ b/internal/cmd/local/local_test.go
@@ -1,11 +1,15 @@
 package local
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
 	"github.com/airbytehq/abctl/internal/cmd/local/paths"
+	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -88,4 +92,40 @@ func TestCheckAirbyteDir(t *testing.T) {
 			t.Errorf("permissions mismatch (-want +got):\n%s", d)
 		}
 	})
+}
+
+func TestValues_FileDoesntExist(t *testing.T) {
+	cmd := InstallCmd{Values: "thisfiledoesnotexist"}
+	err := cmd.Run(context.Background(), k8s.TestProvider, telemetry.NoopClient{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	expect := "failed to read file thisfiledoesnotexist: open thisfiledoesnotexist: no such file or directory"
+	if err.Error() != expect {
+		t.Errorf("expected %q but got %q", expect, err)
+	}
+}
+
+func TestValues_BadYaml(t *testing.T) {
+	tmpdir := t.TempDir()
+	p := filepath.Join(tmpdir, "values.yaml")
+	content := `
+foo:
+  - bar: baz
+    - foo
+`
+
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := InstallCmd{Values: p}
+	err := cmd.Run(context.Background(), k8s.TestProvider, telemetry.NoopClient{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !strings.HasPrefix(err.Error(), "failed to unmarshal file") {
+		t.Errorf("unexpected error: %v", err)
+	}
 }


### PR DESCRIPTION
Validate the user's values file early, before telemetry for the install event starts.