### PR TITLE
feat: nginx config for request size and timeouts

### DIFF
--- a/internal/cmd/local/k8s/provider.go
+++ b/internal/cmd/local/k8s/provider.go
@@ -21,8 +21,6 @@ type Provider struct {
 	Context string
 	// Kubeconfig location
 	Kubeconfig string
-	// HelmNginx additional helm values to pass to the nginx chart
-	HelmNginx []string
 }
 
 // Cluster returns a kubernetes cluster for this provider.
@@ -91,11 +89,6 @@ var (
 		ClusterName: "airbyte-abctl",
 		Context:     "kind-airbyte-abctl",
 		Kubeconfig:  paths.Kubeconfig,
-		HelmNginx: []string{
-			"controller.hostPort.enabled=true",
-			"controller.service.httpsPort.enable=false",
-			"controller.service.type=NodePort",
-		},
 	}
 
 	// TestProvider represents a test provider, for testing purposes
@@ -104,6 +97,5 @@ var (
 		ClusterName: "test-airbyte-abctl",
 		Context:     "test-airbyte-abctl",
 		Kubeconfig:  filepath.Join(os.TempDir(), "abctl", paths.FileKubeconfig),
-		HelmNginx:   []string{},
 	}
 )

--- a/internal/cmd/local/k8s/provider_test.go
+++ b/internal/cmd/local/k8s/provider_test.go
@@ -24,14 +24,6 @@ func TestProvider_Defaults(t *testing.T) {
 		if d := cmp.Diff(paths.Kubeconfig, DefaultProvider.Kubeconfig); d != "" {
 			t.Errorf("Kubeconfig mismatch (-want +got):\n%s", d)
 		}
-		expHelmNginx := []string{
-			"controller.hostPort.enabled=true",
-			"controller.service.httpsPort.enable=false",
-			"controller.service.type=NodePort",
-		}
-		if d := cmp.Diff(expHelmNginx, DefaultProvider.HelmNginx); d != "" {
-			t.Errorf("HelmNginx mismatch (-want +got):\n%s", d)
-		}
 	})
 
 	t.Run("test", func(t *testing.T) {
@@ -52,9 +44,6 @@ func TestProvider_Defaults(t *testing.T) {
 		}
 		if d := cmp.Diff(paths.Kubeconfig, TestProvider.Kubeconfig); d == "" {
 			t.Errorf("Kubeconfig should differ (%s)", paths.Kubeconfig)
-		}
-		if d := cmp.Diff([]string{}, TestProvider.HelmNginx); d != "" {
-			t.Errorf("HelmNginx mismatch (-want +got):\n%s", d)
 		}
 	})
 }

--- a/internal/cmd/local/local/install.go
+++ b/internal/cmd/local/local/install.go
@@ -259,6 +259,12 @@ func (c *Command) Install(ctx context.Context, opts InstallOpts) error {
 		return c.diagnoseAirbyteChartFailure(ctx, err)
 	}
 
+	nginxValues, err := getNginxValuesYaml(c.portHTTP)
+	if err != nil {
+		return err
+	}
+	pterm.Debug.Printfln("nginx values:\n%s", nginxValues)
+
 	if err := c.handleChart(ctx, chartRequest{
 		name:           "nginx",
 		uninstallFirst: true,
@@ -267,7 +273,7 @@ func (c *Command) Install(ctx context.Context, opts InstallOpts) error {
 		chartName:      nginxChartName,
 		chartRelease:   nginxChartRelease,
 		namespace:      nginxNamespace,
-		values:         append(c.provider.HelmNginx, fmt.Sprintf("controller.service.ports.http=%d", c.portHTTP)),
+		valuesYAML:     nginxValues,
 	}); err != nil {
 		// If we timed out, there is a good chance it's due to an unavailable port, check if this is the case.
 		// As the kubernetes client doesn't return usable error types, have to check for a specific string value.
@@ -746,7 +752,7 @@ func determineHelmChartAction(helm helm.Client, chart *chart.Chart, releaseName 
 // values provided were potentially overridden by the valuesYML file.
 func mergeValuesWithValuesYAML(values []string, userValues map[string]any) (string, error) {
 	a := maps.FromSlice(values)
-	
+
 	maps.Merge(a, userValues)
 
 	res, err := maps.ToYAML(a)

--- a/internal/cmd/local/local/install_test.go
+++ b/internal/cmd/local/local/install_test.go
@@ -214,6 +214,7 @@ func TestCommand_Install_HelmValues(t *testing.T) {
 	userID := uuid.New()
 
 	expChartCnt := 0
+	expNginxValues, _ := getNginxValuesYaml(9999)
 	expChart := []struct {
 		chart   helmclient.ChartSpec
 		release release.Release
@@ -254,7 +255,7 @@ func TestCommand_Install_HelmValues(t *testing.T) {
 				CreateNamespace: true,
 				Wait:            true,
 				Timeout:         30 * time.Minute,
-				ValuesOptions:   values.Options{Values: []string{fmt.Sprintf("controller.service.ports.http=%d", portTest)}},
+				ValuesYaml: expNginxValues,
 			},
 			release: release.Release{
 				Chart:     &chart.Chart{Metadata: &chart.Metadata{Version: "4.3.2.1"}},

--- a/internal/cmd/local/local/install_test.go
+++ b/internal/cmd/local/local/install_test.go
@@ -3,7 +3,6 @@ package local
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -13,7 +12,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	helmclient "github.com/mittwald/go-helm-client"
-	"github.com/mittwald/go-helm-client/values"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
@@ -33,6 +31,7 @@ func testChartLocator(chartName, chartVersion string) string {
 }
 
 func TestCommand_Install(t *testing.T) {
+	expNginxValues, _ := getNginxValuesYaml(9999)
 	expChartRepoCnt := 0
 	expChartRepo := []struct {
 		name string
@@ -85,7 +84,7 @@ func TestCommand_Install(t *testing.T) {
 				CreateNamespace: true,
 				Wait:            true,
 				Timeout:         30 * time.Minute,
-				ValuesOptions:   values.Options{Values: []string{fmt.Sprintf("controller.service.ports.http=%d", portTest)}},
+				ValuesYaml:      expNginxValues,
 			},
 			release: release.Release{
 				Chart:     &chart.Chart{Metadata: &chart.Metadata{Version: "4.3.2.1"}},
@@ -255,7 +254,7 @@ func TestCommand_Install_HelmValues(t *testing.T) {
 				CreateNamespace: true,
 				Wait:            true,
 				Timeout:         30 * time.Minute,
-				ValuesYaml: expNginxValues,
+				ValuesYaml:      expNginxValues,
 			},
 			release: release.Release{
 				Chart:     &chart.Chart{Metadata: &chart.Metadata{Version: "4.3.2.1"}},

--- a/internal/cmd/local/local/nginx.go
+++ b/internal/cmd/local/local/nginx.go
@@ -1,0 +1,32 @@
+package local
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+)
+
+var nginxValuesTpl = template.Must(template.New("nginx-values").Parse(`
+controller:
+  hostPort:
+    enabled: true
+  service:
+    type: NodePort
+    ports:
+      http: {{ .Port }}
+    httpsPort:
+      enable: false
+  config:
+    proxy-body-size: 10m
+    proxy-read-timeout: "600"
+    proxy-send-timeout: "600"
+`))
+
+func getNginxValuesYaml(port int) (string, error) {
+	var buf bytes.Buffer
+	err := nginxValuesTpl.Execute(&buf, map[string]any{"Port": port})
+	if err != nil {
+		return "", fmt.Errorf("failed to build nginx values yaml: %w", err)
+	}
+	return buf.String(), nil
+}


### PR DESCRIPTION
Set up some nginx config for request body size and timeouts.

Related issues:
- https://github.com/airbytehq/airbyte/issues/45423
- https://github.com/airbytehq/airbyte/issues/45156
- https://github.com/airbytehq/airbyte/issues/43893
- https://github.com/airbytehq/airbyte-internal-issues/issues/9859

Unfortunately, I think this will only work on new installs or uninstall + reinstall. In my tests, I couldn't get this to update my existing ingress.

The request body size is fairly easy to test by creating a postgres source with lots of tables/columns:
<img width="1334" alt="Screenshot 2024-09-20 at 11 47 47 AM" src="https://github.com/user-attachments/assets/b2424e12-b99c-403f-82eb-56faa22ed78f">

after:
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/9ba920f3-8f74-47dc-80ab-e846bc9d93fc">

I'm not sure how to test the timeout setting yet.