### PR TITLE
fix: xor with --chart and --chart-version flags

### DIFF
--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -15,7 +15,7 @@ import (
 
 type InstallCmd struct {
 	Chart           string   `help:"Path to chart." xor:"chartver"`
-	ChartVersion    string   `default:"latest" help:"Version to install." xor:"chartver"`
+	ChartVersion    string   `help:"Version to install." xor:"chartver"`
 	DockerEmail     string   `group:"docker" help:"Docker email." env:"ABCTL_LOCAL_INSTALL_DOCKER_EMAIL"`
 	DockerPassword  string   `group:"docker" help:"Docker password." env:"ABCTL_LOCAL_INSTALL_DOCKER_PASSWORD"`
 	DockerServer    string   `group:"docker" default:"https://index.docker.io/v1/" help:"Docker server." env:"ABCTL_LOCAL_INSTALL_DOCKER_SERVER"`
@@ -131,10 +131,6 @@ func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient t
 			NoBrowser:       i.NoBrowser,
 			LowResourceMode: i.LowResourceMode,
 			InsecureCookies: i.InsecureCookies,
-		}
-
-		if opts.HelmChartVersion == "latest" {
-			opts.HelmChartVersion = ""
 		}
 
 		if err := lc.Install(ctx, opts); err != nil {


### PR DESCRIPTION
https://github.com/airbytehq/abctl/pull/121#issuecomment-2376707121

The default on the `--chart-version` flag doesn't work with the `xor` on the `--chart` and `--chart-version` flags.

The default "latest" was getting converted to "" anyway, so this change just sets the default to ""