### PR TITLE
fix: bump helm timeout to 60 minutes

### DIFF
--- a/internal/cmd/local/local/install.go
+++ b/internal/cmd/local/local/install.go
@@ -604,7 +604,7 @@ func (c *Command) handleChart(
 		CreateNamespace: true,
 		Namespace:       req.namespace,
 		Wait:            true,
-		Timeout:         30 * time.Minute,
+		Timeout:         60 * time.Minute,
 		ValuesOptions:   values.Options{Values: req.values},
 		ValuesYaml:      req.valuesYAML,
 		Version:         req.chartVersion,

--- a/internal/cmd/local/local/install_test.go
+++ b/internal/cmd/local/local/install_test.go
@@ -56,7 +56,7 @@ func TestCommand_Install(t *testing.T) {
 				Namespace:       airbyteNamespace,
 				CreateNamespace: true,
 				Wait:            true,
-				Timeout:         30 * time.Minute,
+				Timeout:         60 * time.Minute,
 				ValuesYaml: `global:
     auth:
         enabled: "true"
@@ -83,7 +83,7 @@ func TestCommand_Install(t *testing.T) {
 				Namespace:       nginxNamespace,
 				CreateNamespace: true,
 				Wait:            true,
-				Timeout:         30 * time.Minute,
+				Timeout:         60 * time.Minute,
 				ValuesYaml:      expNginxValues,
 			},
 			release: release.Release{
@@ -225,7 +225,7 @@ func TestCommand_Install_HelmValues(t *testing.T) {
 				Namespace:       airbyteNamespace,
 				CreateNamespace: true,
 				Wait:            true,
-				Timeout:         30 * time.Minute,
+				Timeout:         60 * time.Minute,
 				ValuesYaml: `global:
     auth:
         enabled: "true"
@@ -253,7 +253,7 @@ func TestCommand_Install_HelmValues(t *testing.T) {
 				Namespace:       nginxNamespace,
 				CreateNamespace: true,
 				Wait:            true,
-				Timeout:         30 * time.Minute,
+				Timeout:         60 * time.Minute,
 				ValuesYaml:      expNginxValues,
 			},
 			release: release.Release{


### PR DESCRIPTION
Bump helm timeout from 30 to 60 minutes to allow more time for the system to start and hopefully make a dent in timeout errors