### PR TITLE
feat: add images manifest command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc6
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pterm/pterm v0.12.79
-	github.com/stretchr/testify v1.8.4
 	golang.org/x/mod v0.17.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.14.2
@@ -121,7 +120,6 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,13 +14,14 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc6
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pterm/pterm v0.12.79
+	github.com/stretchr/testify v1.8.4
 	golang.org/x/mod v0.17.0
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.14.2
 	k8s.io/api v0.29.2
 	k8s.io/apimachinery v0.29.2
 	k8s.io/client-go v0.29.2
+	k8s.io/kubectl v0.29.0
 	sigs.k8s.io/kind v0.24.0
 )
 
@@ -120,6 +121,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
@@ -158,13 +160,13 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/evanphx/json-patch.v5 v5.7.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiextensions-apiserver v0.29.0 // indirect
 	k8s.io/apiserver v0.29.0 // indirect
 	k8s.io/cli-runtime v0.29.0 // indirect
 	k8s.io/component-base v0.29.0 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240103195357-a9f8850cb432 // indirect
-	k8s.io/kubectl v0.29.0 // indirect
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e // indirect
 	oras.land/oras-go v1.2.5 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
+	"github.com/airbytehq/abctl/internal/cmd/images"
 	"github.com/airbytehq/abctl/internal/cmd/local"
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
 	"github.com/airbytehq/abctl/internal/cmd/local/localerr"
@@ -24,14 +24,12 @@ func (v verbose) BeforeApply() error {
 
 type Cmd struct {
 	Local   local.Cmd   `cmd:"" help:"Manage the local Airbyte installation."`
+	Images  images.Cmd  `cmd:"" help:"Manage images used by Airbyte and abctl."`
 	Version version.Cmd `cmd:"" help:"Display version information."`
 	Verbose verbose     `short:"v" help:"Enable verbose output."`
 }
 
 func (c *Cmd) BeforeApply(ctx *kong.Context) error {
-	if _, envVarDNT := os.LookupEnv("DO_NOT_TRACK"); envVarDNT {
-		pterm.Info.Println("Telemetry collection disabled (DO_NOT_TRACK)")
-	}
 	ctx.BindTo(k8s.DefaultProvider, (*k8s.Provider)(nil))
 	ctx.BindTo(telemetry.Get(), (*telemetry.Client)(nil))
 	if err := ctx.BindToProvider(bindK8sClient(&k8s.DefaultProvider)); err != nil {

--- a/internal/cmd/images/images_cmd.go
+++ b/internal/cmd/images/images_cmd.go
@@ -1,0 +1,5 @@
+package images
+
+type Cmd struct {
+	Manifest ManifestCmd `cmd:"" help:"Display a manifest of images used by Airbyte and abctl."`
+}

--- a/internal/cmd/images/manifest_cmd.go
+++ b/internal/cmd/images/manifest_cmd.go
@@ -21,7 +21,7 @@ import (
 
 type ManifestCmd struct {
 	Chart        string `help:"Path to chart." xor:"chartver"`
-	ChartVersion string `help:"Version to install." xor:"chartver"`
+	ChartVersion string `help:"Version of the chart." xor:"chartver"`
 	Values       string `type:"existingfile" help:"An Airbyte helm chart values file to configure helm."`
 }
 

--- a/internal/cmd/images/manifest_cmd.go
+++ b/internal/cmd/images/manifest_cmd.go
@@ -1,0 +1,147 @@
+package images
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/airbytehq/abctl/internal/cmd/local/helm"
+	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
+	helmlib "github.com/mittwald/go-helm-client"
+	"helm.sh/helm/v3/pkg/repo"
+
+	"github.com/airbytehq/abctl/internal/common"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubectl/pkg/scheme"
+)
+
+type ManifestCmd struct {
+	Chart        string `help:"Path to chart." xor:"chartver"`
+	ChartVersion string `help:"Version to install." xor:"chartver"`
+	Values       string `type:"existingfile" help:"An Airbyte helm chart values file to configure helm."`
+}
+
+func (c *ManifestCmd) Run(provider k8s.Provider) error {
+
+	client, err := helm.New(provider.Kubeconfig, provider.Context, common.AirbyteNamespace)
+	if err != nil {
+		return err
+	}
+
+	images, err := c.findAirbyteImages(client)
+	if err != nil {
+		return err
+	}
+
+	for _, img := range images {
+		fmt.Println(img)
+	}
+
+	return nil
+}
+
+func (c *ManifestCmd) findAirbyteImages(client helm.Client) ([]string, error) {
+	valuesYaml, err := helm.BuildAirbyteValues(helm.ValuesOpts{
+		ValuesFile: c.Values,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	airbyteChartLoc := helm.LocateLatestAirbyteChart(c.ChartVersion, c.Chart)
+	return findImagesFromChart(client, valuesYaml, airbyteChartLoc, c.ChartVersion)
+}
+
+func findImagesFromChart(client helm.Client, valuesYaml, chartName, chartVersion string) ([]string, error) {
+	err := client.AddOrUpdateChartRepo(repo.Entry{
+		Name: common.AirbyteRepoName,
+		URL:  common.AirbyteRepoURL,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	bytes, err := client.TemplateChart(&helmlib.ChartSpec{
+		ChartName:    chartName,
+		GenerateName: true,
+		ValuesYaml:   valuesYaml,
+		Version:      chartVersion,
+	}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	images := findAllImages(string(bytes))
+	return images, nil
+}
+
+// findAllImages walks through the Helm chart, looking for container images in k8s PodSpecs.
+// It also looks for env vars in the airbyte-env config map that end with "_IMAGE".
+// It returns a unique, sorted list of images found.
+func findAllImages(chartYaml string) []string {
+	objs := decodeK8sResources(chartYaml)
+	imageSet := map[string]bool{}
+
+	for _, obj := range objs {
+
+		var podSpec *corev1.PodSpec
+		switch z := obj.(type) {
+		case *corev1.ConfigMap:
+			if strings.HasSuffix(z.Name, "airbyte-env") {
+				for k, v := range z.Data {
+					if strings.HasSuffix(k, "_IMAGE") {
+						imageSet[v] = true
+					}
+				}
+			}
+			continue
+		case *corev1.Pod:
+			podSpec = &z.Spec
+		case *batchv1.Job:
+			podSpec = &z.Spec.Template.Spec
+		case *appsv1.Deployment:
+			podSpec = &z.Spec.Template.Spec
+		case *appsv1.StatefulSet:
+			podSpec = &z.Spec.Template.Spec
+		default:
+			continue
+		}
+
+		for _, c := range podSpec.InitContainers {
+			imageSet[c.Image] = true
+		}
+		for _, c := range podSpec.Containers {
+			imageSet[c.Image] = true
+		}
+	}
+
+	var out []string
+	for k := range imageSet {
+		if k != "" {
+			out = append(out, k)
+		}
+	}
+	slices.Sort(out)
+
+	return out
+}
+
+func decodeK8sResources(renderedYaml string) []runtime.Object {
+	out := []runtime.Object{}
+	chunks := strings.Split(renderedYaml, "---")
+	for _, chunk := range chunks {
+		if len(chunk) == 0 {
+			continue
+		}
+		obj, _, err := scheme.Codecs.UniversalDeserializer().Decode([]byte(chunk), nil, nil)
+		if err != nil {
+			continue
+		}
+		out = append(out, obj)
+	}
+	return out
+}

--- a/internal/cmd/images/manifest_cmd_test.go
+++ b/internal/cmd/images/manifest_cmd_test.go
@@ -3,15 +3,14 @@ package images
 import (
 	"testing"
 
+	helmlib "github.com/mittwald/go-helm-client"
+
 	"github.com/airbytehq/abctl/internal/cmd/local/helm"
-	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
-	"github.com/airbytehq/abctl/internal/common"
 	"github.com/stretchr/testify/assert"
 )
 
 func getHelmTestClient(t *testing.T) helm.Client {
-	provider := k8s.DefaultProvider
-	client, err := helm.New(provider.Kubeconfig, provider.Context, common.AirbyteNamespace)
+	client, err := helmlib.New(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +78,6 @@ func TestManifestCmd_Enterprise(t *testing.T) {
 	assert.Equal(t, expect, actual)
 }
 
-
 func TestManifestCmd_Nightly(t *testing.T) {
 	client := getHelmTestClient(t)
 	cmd := ManifestCmd{
@@ -92,27 +90,27 @@ func TestManifestCmd_Nightly(t *testing.T) {
 		t.Fatal(err)
 	}
 	expect := []string{
-		"airbyte/bootloader:nightly-1728428783-9025e1a46e", 
-		"airbyte/connector-builder-server:nightly-1728428783-9025e1a46e", 
-		"airbyte/connector-sidecar:nightly-1728428783-9025e1a46e", 
-		"airbyte/container-orchestrator:nightly-1728428783-9025e1a46e", 
-		"airbyte/cron:nightly-1728428783-9025e1a46e", 
-		"airbyte/db:nightly-1728428783-9025e1a46e", 
-		"airbyte/keycloak-setup:nightly-1728428783-9025e1a46e", 
-		"airbyte/keycloak:nightly-1728428783-9025e1a46e", 
-		"airbyte/mc:latest", 
-		"airbyte/server:nightly-1728428783-9025e1a46e", 
-		"airbyte/webapp:nightly-1728428783-9025e1a46e", 
-		"airbyte/worker:nightly-1728428783-9025e1a46e", 
-		"airbyte/workload-api-server:nightly-1728428783-9025e1a46e", 
-		"airbyte/workload-init-container:nightly-1728428783-9025e1a46e", 
-		"airbyte/workload-launcher:nightly-1728428783-9025e1a46e", 
-		"bitnami/kubectl:1.28.9", 
-		"busybox:1.35", 
-		"busybox:latest", 
-		"curlimages/curl:8.1.1", 
-		"minio/minio:RELEASE.2023-11-20T22-40-07Z", 
-		"postgres:13-alpine", 
+		"airbyte/bootloader:nightly-1728428783-9025e1a46e",
+		"airbyte/connector-builder-server:nightly-1728428783-9025e1a46e",
+		"airbyte/connector-sidecar:nightly-1728428783-9025e1a46e",
+		"airbyte/container-orchestrator:nightly-1728428783-9025e1a46e",
+		"airbyte/cron:nightly-1728428783-9025e1a46e",
+		"airbyte/db:nightly-1728428783-9025e1a46e",
+		"airbyte/keycloak-setup:nightly-1728428783-9025e1a46e",
+		"airbyte/keycloak:nightly-1728428783-9025e1a46e",
+		"airbyte/mc:latest",
+		"airbyte/server:nightly-1728428783-9025e1a46e",
+		"airbyte/webapp:nightly-1728428783-9025e1a46e",
+		"airbyte/worker:nightly-1728428783-9025e1a46e",
+		"airbyte/workload-api-server:nightly-1728428783-9025e1a46e",
+		"airbyte/workload-init-container:nightly-1728428783-9025e1a46e",
+		"airbyte/workload-launcher:nightly-1728428783-9025e1a46e",
+		"bitnami/kubectl:1.28.9",
+		"busybox:1.35",
+		"busybox:latest",
+		"curlimages/curl:8.1.1",
+		"minio/minio:RELEASE.2023-11-20T22-40-07Z",
+		"postgres:13-alpine",
 		"temporalio/auto-setup:1.23.0",
 	}
 	assert.Equal(t, expect, actual)

--- a/internal/cmd/images/manifest_cmd_test.go
+++ b/internal/cmd/images/manifest_cmd_test.go
@@ -1,12 +1,13 @@
 package images
 
 import (
+	"sort"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	helmlib "github.com/mittwald/go-helm-client"
 
 	"github.com/airbytehq/abctl/internal/cmd/local/helm"
-	"github.com/stretchr/testify/assert"
 )
 
 func getHelmTestClient(t *testing.T) helm.Client {
@@ -42,7 +43,7 @@ func TestManifestCmd(t *testing.T) {
 		"minio/minio:RELEASE.2023-11-20T22-40-07Z",
 		"temporalio/auto-setup:1.23.0",
 	}
-	assert.Equal(t, expect, actual)
+	compareList(t, expect, actual)
 }
 
 func TestManifestCmd_Enterprise(t *testing.T) {
@@ -75,7 +76,7 @@ func TestManifestCmd_Enterprise(t *testing.T) {
 		"postgres:13-alpine",
 		"temporalio/auto-setup:1.23.0",
 	}
-	assert.Equal(t, expect, actual)
+	compareList(t, expect, actual)
 }
 
 func TestManifestCmd_Nightly(t *testing.T) {
@@ -113,5 +114,14 @@ func TestManifestCmd_Nightly(t *testing.T) {
 		"postgres:13-alpine",
 		"temporalio/auto-setup:1.23.0",
 	}
-	assert.Equal(t, expect, actual)
+	compareList(t, expect, actual)
+}
+
+func compareList(t *testing.T, expect, actual []string) {
+	t.Helper()
+	sort.Strings(expect)
+	sort.Strings(actual)
+	if d := cmp.Diff(expect, actual); d != "" {
+		t.Error(d)
+	}
 }

--- a/internal/cmd/images/manifest_cmd_test.go
+++ b/internal/cmd/images/manifest_cmd_test.go
@@ -1,0 +1,119 @@
+package images
+
+import (
+	"testing"
+
+	"github.com/airbytehq/abctl/internal/cmd/local/helm"
+	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
+	"github.com/airbytehq/abctl/internal/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func getHelmTestClient(t *testing.T) helm.Client {
+	provider := k8s.DefaultProvider
+	client, err := helm.New(provider.Kubeconfig, provider.Context, common.AirbyteNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func TestManifestCmd(t *testing.T) {
+	client := getHelmTestClient(t)
+	cmd := ManifestCmd{
+		ChartVersion: "1.1.0",
+	}
+	actual, err := cmd.findAirbyteImages(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect := []string{
+		"airbyte/bootloader:1.1.0",
+		"airbyte/connector-builder-server:1.1.0",
+		"airbyte/cron:1.1.0",
+		"airbyte/db:1.1.0",
+		"airbyte/mc",
+		"airbyte/server:1.1.0",
+		"airbyte/webapp:1.1.0",
+		"airbyte/worker:1.1.0",
+		"airbyte/workload-api-server:1.1.0",
+		"airbyte/workload-launcher:1.1.0",
+		"bitnami/kubectl:1.28.9",
+		"busybox",
+		"minio/minio:RELEASE.2023-11-20T22-40-07Z",
+		"temporalio/auto-setup:1.23.0",
+	}
+	assert.Equal(t, expect, actual)
+}
+
+func TestManifestCmd_Enterprise(t *testing.T) {
+	client := getHelmTestClient(t)
+	cmd := ManifestCmd{
+		ChartVersion: "1.1.0",
+		Values:       "testdata/enterprise.values.yaml",
+	}
+	actual, err := cmd.findAirbyteImages(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect := []string{
+		"airbyte/bootloader:1.1.0",
+		"airbyte/connector-builder-server:1.1.0",
+		"airbyte/cron:1.1.0",
+		"airbyte/db:1.1.0",
+		"airbyte/keycloak-setup:1.1.0",
+		"airbyte/keycloak:1.1.0",
+		"airbyte/mc",
+		"airbyte/server:1.1.0",
+		"airbyte/webapp:1.1.0",
+		"airbyte/worker:1.1.0",
+		"airbyte/workload-api-server:1.1.0",
+		"airbyte/workload-launcher:1.1.0",
+		"bitnami/kubectl:1.28.9",
+		"busybox",
+		"curlimages/curl:8.1.1",
+		"minio/minio:RELEASE.2023-11-20T22-40-07Z",
+		"postgres:13-alpine",
+		"temporalio/auto-setup:1.23.0",
+	}
+	assert.Equal(t, expect, actual)
+}
+
+
+func TestManifestCmd_Nightly(t *testing.T) {
+	client := getHelmTestClient(t)
+	cmd := ManifestCmd{
+		// This version includes chart fixes that expose images more consistently and completely.
+		ChartVersion: "1.1.0-nightly-1728428783-9025e1a46e",
+		Values:       "testdata/enterprise.values.yaml",
+	}
+	actual, err := cmd.findAirbyteImages(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect := []string{
+		"airbyte/bootloader:nightly-1728428783-9025e1a46e", 
+		"airbyte/connector-builder-server:nightly-1728428783-9025e1a46e", 
+		"airbyte/connector-sidecar:nightly-1728428783-9025e1a46e", 
+		"airbyte/container-orchestrator:nightly-1728428783-9025e1a46e", 
+		"airbyte/cron:nightly-1728428783-9025e1a46e", 
+		"airbyte/db:nightly-1728428783-9025e1a46e", 
+		"airbyte/keycloak-setup:nightly-1728428783-9025e1a46e", 
+		"airbyte/keycloak:nightly-1728428783-9025e1a46e", 
+		"airbyte/mc:latest", 
+		"airbyte/server:nightly-1728428783-9025e1a46e", 
+		"airbyte/webapp:nightly-1728428783-9025e1a46e", 
+		"airbyte/worker:nightly-1728428783-9025e1a46e", 
+		"airbyte/workload-api-server:nightly-1728428783-9025e1a46e", 
+		"airbyte/workload-init-container:nightly-1728428783-9025e1a46e", 
+		"airbyte/workload-launcher:nightly-1728428783-9025e1a46e", 
+		"bitnami/kubectl:1.28.9", 
+		"busybox:1.35", 
+		"busybox:latest", 
+		"curlimages/curl:8.1.1", 
+		"minio/minio:RELEASE.2023-11-20T22-40-07Z", 
+		"postgres:13-alpine", 
+		"temporalio/auto-setup:1.23.0",
+	}
+	assert.Equal(t, expect, actual)
+}

--- a/internal/cmd/images/testdata/enterprise.values.yaml
+++ b/internal/cmd/images/testdata/enterprise.values.yaml
@@ -1,0 +1,14 @@
+global:
+  airbyteUrl: "http://localhost:8000"
+  edition: "enterprise"
+
+  auth:
+    enabled: false
+    instanceAdmin:
+      firstName: "test"
+      lastName:  "user"
+
+keycloak:
+  auth:
+    adminUsername: airbyteAdmin
+    adminPassword: keycloak123

--- a/internal/cmd/local/check_test.go
+++ b/internal/cmd/local/check_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/docker/docker/api/types/system"
 	"github.com/docker/go-connections/nat"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/uuid"
 )
 
 func TestDockerInstalled(t *testing.T) {
@@ -40,9 +39,7 @@ func TestDockerInstalled(t *testing.T) {
 		},
 	}
 
-	tel := mockTelemetryClient{
-		attr: func(key, val string) {},
-	}
+	tel := telemetry.MockClient{}
 
 	version, err := dockerInstalled(context.Background(), &tel)
 	if err != nil {
@@ -73,7 +70,7 @@ func TestDockerInstalled_Error(t *testing.T) {
 		},
 	}
 
-	_, err := dockerInstalled(context.Background(), &mockTelemetryClient{})
+	_, err := dockerInstalled(context.Background(), &telemetry.MockClient{})
 	if err == nil {
 		t.Error("unexpected error:", err)
 	}
@@ -302,40 +299,4 @@ func port(s string) int {
 	vals := strings.Split(s, ":")
 	p, _ := strconv.Atoi(vals[len(vals)-1])
 	return p
-}
-
-// --- mocks
-var _ telemetry.Client = (*mockTelemetryClient)(nil)
-
-type mockTelemetryClient struct {
-	start   func(ctx context.Context, eventType telemetry.EventType) error
-	success func(ctx context.Context, eventType telemetry.EventType) error
-	failure func(ctx context.Context, eventType telemetry.EventType, err error) error
-	attr    func(key, val string)
-	user    func() uuid.UUID
-	wrap    func(context.Context, telemetry.EventType, func() error) error
-}
-
-func (m *mockTelemetryClient) Start(ctx context.Context, eventType telemetry.EventType) error {
-	return m.start(ctx, eventType)
-}
-
-func (m *mockTelemetryClient) Success(ctx context.Context, eventType telemetry.EventType) error {
-	return m.success(ctx, eventType)
-}
-
-func (m *mockTelemetryClient) Failure(ctx context.Context, eventType telemetry.EventType, err error) error {
-	return m.failure(ctx, eventType, err)
-}
-
-func (m *mockTelemetryClient) Attr(key, val string) {
-	m.attr(key, val)
-}
-
-func (m *mockTelemetryClient) User() uuid.UUID {
-	return m.user()
-}
-
-func (m *mockTelemetryClient) Wrap(ctx context.Context, et telemetry.EventType, f func() error) error {
-	return m.wrap(ctx, et, f)
 }

--- a/internal/cmd/local/helm/airbyte_values.go
+++ b/internal/cmd/local/helm/airbyte_values.go
@@ -1,0 +1,76 @@
+package helm
+
+import (
+	"fmt"
+
+	"github.com/airbytehq/abctl/internal/maps"
+)
+
+type ValuesOpts struct {
+	ValuesFile      string
+	LowResourceMode bool
+	InsecureCookies bool
+	TelemetryUser   string
+	ImagePullSecret string
+}
+
+func BuildAirbyteValues(opts ValuesOpts) (string, error) {
+
+	vals := []string{
+		"global.env_vars.AIRBYTE_INSTALLATION_ID=" + opts.TelemetryUser,
+		"global.auth.enabled=true",
+		"global.jobs.resources.limits.cpu=3",
+		"global.jobs.resources.limits.memory=4Gi",
+	}
+
+	if opts.LowResourceMode {
+		vals = append(vals,
+			"server.env_vars.JOB_RESOURCE_VARIANT_OVERRIDE=lowresource",
+			"global.jobs.resources.requests.cpu=0",
+			"global.jobs.resources.requests.memory=0",
+
+			"workload-launcher.env_vars.CHECK_JOB_MAIN_CONTAINER_CPU_REQUEST=0",
+			"workload-launcher.env_vars.CHECK_JOB_MAIN_CONTAINER_MEMORY_REQUEST=0",
+			"workload-launcher.env_vars.DISCOVER_JOB_MAIN_CONTAINER_CPU_REQUEST=0",
+			"workload-launcher.env_vars.DISCOVER_JOB_MAIN_CONTAINER_MEMORY_REQUEST=0",
+			"workload-launcher.env_vars.SPEC_JOB_MAIN_CONTAINER_CPU_REQUEST=0",
+			"workload-launcher.env_vars.SPEC_JOB_MAIN_CONTAINER_MEMORY_REQUEST=0",
+			"workload-launcher.env_vars.SIDECAR_MAIN_CONTAINER_CPU_REQUEST=0",
+			"workload-launcher.env_vars.SIDECAR_MAIN_CONTAINER_MEMORY_REQUEST=0",
+		)
+	}
+
+	if opts.ImagePullSecret != "" {
+		vals = append(vals, fmt.Sprintf("global.imagePullSecrets[0].name=%s", opts.ImagePullSecret))
+	}
+
+	if opts.InsecureCookies {
+		vals = append(vals, "global.auth.cookieSecureSetting=false")
+	}
+
+	fileVals, err := maps.FromYAMLFile(opts.ValuesFile)
+	if err != nil {
+		return "", err
+	}
+
+	return mergeValuesWithValuesYAML(vals, fileVals)
+}
+
+// mergeValuesWithValuesYAML ensures that the values defined within this code have a lower
+// priority than any values defined in a values.yaml file.
+// By default, the helm-client we're using reversed this priority, putting the values
+// defined in this code at a higher priority than the values defined in the values.yaml file.
+// This function returns a string representation of the value.yaml file after all
+// values provided were potentially overridden by the valuesYML file.
+func mergeValuesWithValuesYAML(values []string, userValues map[string]any) (string, error) {
+	a := maps.FromSlice(values)
+
+	maps.Merge(a, userValues)
+
+	res, err := maps.ToYAML(a)
+	if err != nil {
+		return "", fmt.Errorf("unable to merge values: %w", err)
+	}
+
+	return res, nil
+}

--- a/internal/cmd/local/helm/helm.go
+++ b/internal/cmd/local/helm/helm.go
@@ -23,6 +23,7 @@ type Client interface {
 	GetRelease(name string) (*release.Release, error)
 	InstallOrUpgradeChart(ctx context.Context, spec *helmclient.ChartSpec, opts *helmclient.GenericHelmOptions) (*release.Release, error)
 	UninstallReleaseByName(name string) error
+	TemplateChart(spec *helmclient.ChartSpec, options *helmclient.HelmTemplateOptions) ([]byte, error)
 }
 
 // New returns the default helm client

--- a/internal/cmd/local/helm/locate.go
+++ b/internal/cmd/local/helm/locate.go
@@ -1,10 +1,11 @@
-package local
+package helm
 
 import (
 	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/airbytehq/abctl/internal/common"
 	"github.com/pterm/pterm"
 	"golang.org/x/mod/semver"
 	"helm.sh/helm/v3/pkg/cli"
@@ -40,8 +41,8 @@ var defaultNewChartRepo newChartRepo = func(cfg *repo.Entry, getters getter.Prov
 // This variable should only be modified for testing purposes.
 var defaultLoadIndexFile loadIndexFile = repo.LoadIndexFile
 
-func locateLatestAirbyteChart(chartName, chartVersion, chartFlag string) string {
-	pterm.Debug.Printf("getting helm chart %q with version %q\n", chartName, chartVersion)
+func LocateLatestAirbyteChart(chartVersion, chartFlag string) string {
+	pterm.Debug.Printf("getting helm chart %q with version %q\n", common.AirbyteChartName, chartVersion)
 
 	// If the --chart flag was given, use that.
 	if chartFlag != "" {
@@ -55,8 +56,8 @@ func locateLatestAirbyteChart(chartName, chartVersion, chartFlag string) string 
 	// Here we avoid that problem by figuring out the full URL of the airbyte chart,
 	// which forces Helm to resolve the chart over HTTP and ignore local directories.
 	// If the locator fails, fall back to the original helm behavior.
-	if chartName == airbyteChartName && chartVersion == "" {
-		if url, err := getLatestAirbyteChartUrlFromRepoIndex(airbyteRepoName, airbyteRepoURL); err == nil {
+	if chartVersion == "" {
+		if url, err := getLatestAirbyteChartUrlFromRepoIndex(common.AirbyteRepoName, common.AirbyteRepoURL); err == nil {
 			pterm.Debug.Printf("determined latest airbyte chart url: %s\n", url)
 			return url
 		} else {
@@ -64,7 +65,7 @@ func locateLatestAirbyteChart(chartName, chartVersion, chartFlag string) string 
 		}
 	}
 
-	return chartName
+	return common.AirbyteChartName
 }
 
 func getLatestAirbyteChartUrlFromRepoIndex(repoName, repoUrl string) (string, error) {
@@ -117,5 +118,5 @@ func getLatestAirbyteChartUrlFromRepoIndex(repoName, repoUrl string) (string, er
 		return "", fmt.Errorf("unexpected number of URLs - %d", len(latest.URLs))
 	}
 
-	return airbyteRepoURL + "/" + latest.URLs[0], nil
+	return common.AirbyteRepoURL + "/" + latest.URLs[0], nil
 }

--- a/internal/cmd/local/helm/locate_test.go
+++ b/internal/cmd/local/helm/locate_test.go
@@ -1,8 +1,9 @@
-package local
+package helm
 
 import (
 	"testing"
 
+	"github.com/airbytehq/abctl/internal/common"
 	"github.com/google/go-cmp/cmp"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/getter"
@@ -11,7 +12,7 @@ import (
 
 func TestLocateChartFlag(t *testing.T) {
 	expect := "chartFlagValue"
-	c := locateLatestAirbyteChart("airbyte", "", expect)
+	c := LocateLatestAirbyteChart("", expect)
 	if c != expect {
 		t.Errorf("expected %q but got %q", expect, c)
 	}
@@ -40,7 +41,7 @@ func TestLocate(t *testing.T) {
 					URLs:     []string{"example.test"},
 				}},
 			},
-			exp: airbyteRepoURL + "/example.test",
+			exp: common.AirbyteRepoURL + "/example.test",
 		},
 		{
 			name: "one non-release entry",
@@ -50,12 +51,12 @@ func TestLocate(t *testing.T) {
 					URLs:     []string{"example.test"},
 				}},
 			},
-			exp: airbyteChartName,
+			exp: common.AirbyteChartName,
 		},
 		{
 			name:    "no entries",
 			entries: map[string]repo.ChartVersions{},
-			exp:     airbyteChartName,
+			exp:     common.AirbyteChartName,
 		},
 		{
 			name: "one release entry with no URLs",
@@ -65,7 +66,7 @@ func TestLocate(t *testing.T) {
 					URLs:     []string{},
 				}},
 			},
-			exp: airbyteChartName,
+			exp: common.AirbyteChartName,
 		},
 		{
 			name: "one release entry with two URLs",
@@ -75,7 +76,7 @@ func TestLocate(t *testing.T) {
 					URLs:     []string{"one.test", "two.test"},
 				}},
 			},
-			exp: airbyteChartName,
+			exp: common.AirbyteChartName,
 		},
 		{
 			name: "one non-release entry followed by one release entry",
@@ -91,14 +92,14 @@ func TestLocate(t *testing.T) {
 					},
 				},
 			},
-			exp: airbyteRepoURL + "/good.test",
+			exp: common.AirbyteRepoURL + "/good.test",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defaultLoadIndexFile = mockLoadIndexFile(repo.IndexFile{Entries: tt.entries})
-			act := locateLatestAirbyteChart(airbyteChartName, "", "")
+			act := LocateLatestAirbyteChart("", "")
 			if d := cmp.Diff(tt.exp, act); d != "" {
 				t.Errorf("mismatch (-want +got):\n%s", d)
 			}

--- a/internal/cmd/local/helm/nginx_values.go
+++ b/internal/cmd/local/helm/nginx_values.go
@@ -1,4 +1,4 @@
-package local
+package helm
 
 import (
 	"bytes"
@@ -22,7 +22,7 @@ controller:
     proxy-send-timeout: "600"
 `))
 
-func getNginxValuesYaml(port int) (string, error) {
+func BuildNginxValues(port int) (string, error) {
 	var buf bytes.Buffer
 	err := nginxValuesTpl.Execute(&buf, map[string]any{"Port": port})
 	if err != nil {

--- a/internal/cmd/local/local.go
+++ b/internal/cmd/local/local.go
@@ -21,6 +21,11 @@ type Cmd struct {
 }
 
 func (c *Cmd) BeforeApply() error {
+
+	if _, envVarDNT := os.LookupEnv("DO_NOT_TRACK"); envVarDNT {
+		pterm.Info.Println("Telemetry collection disabled (DO_NOT_TRACK)")
+	}
+
 	if err := checkAirbyteDir(); err != nil {
 		return fmt.Errorf("%w: %w", localerr.ErrAirbyteDir, err)
 	}

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -33,14 +33,14 @@ type Command struct {
 	provider k8s.Provider
 	docker   *docker.Docker
 
-	http        HTTPClient
-	helm        helm.Client
-	k8s         k8s.Client
-	portHTTP    int
-	spinner     *pterm.SpinnerPrinter
-	tel         telemetry.Client
-	launcher    BrowserLauncher
-	userHome    string
+	http     HTTPClient
+	helm     helm.Client
+	k8s      k8s.Client
+	portHTTP int
+	spinner  *pterm.SpinnerPrinter
+	tel      telemetry.Client
+	launcher BrowserLauncher
+	userHome string
 }
 
 // Option for configuring the Command, primarily exists for testing

--- a/internal/cmd/local/local/cmd.go
+++ b/internal/cmd/local/local/cmd.go
@@ -5,9 +5,11 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/airbytehq/abctl/internal/cmd/local/docker"
 	"github.com/airbytehq/abctl/internal/cmd/local/helm"
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s/kind"
 	"github.com/airbytehq/abctl/internal/cmd/local/paths"
+	"github.com/airbytehq/abctl/internal/common"
 	"k8s.io/client-go/rest"
 
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
@@ -19,24 +21,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const (
-	airbyteBootloaderPodName = "airbyte-abctl-airbyte-bootloader"
-	airbyteChartName         = "airbyte/airbyte"
-	airbyteChartRelease      = "airbyte-abctl"
-	airbyteIngress           = "ingress-abctl"
-	airbyteNamespace         = "airbyte-abctl"
-	airbyteRepoName          = "airbyte"
-	airbyteRepoURL           = "https://airbytehq.github.io/helm-charts"
-	nginxChartName           = "nginx/ingress-nginx"
-	nginxChartRelease        = "ingress-nginx"
-	nginxNamespace           = "ingress-nginx"
-	nginxRepoName            = "nginx"
-	nginxRepoURL             = "https://kubernetes.github.io/ingress-nginx"
-)
-
-// dockerAuthSecretName is the name of the secret which holds the docker authentication information.
-const dockerAuthSecretName = "docker-auth"
-
 type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
@@ -44,12 +28,11 @@ type HTTPClient interface {
 // BrowserLauncher primarily for testing purposes.
 type BrowserLauncher func(url string) error
 
-// ChartLocator primarily for testing purposes.
-type ChartLocator func(repoName, repoUrl, chartFlag string) string
-
 // Command is the local command, responsible for installing, uninstalling, or other local actions.
 type Command struct {
-	provider    k8s.Provider
+	provider k8s.Provider
+	docker   *docker.Docker
+
 	http        HTTPClient
 	helm        helm.Client
 	k8s         k8s.Client
@@ -57,12 +40,17 @@ type Command struct {
 	spinner     *pterm.SpinnerPrinter
 	tel         telemetry.Client
 	launcher    BrowserLauncher
-	locateChart ChartLocator
 	userHome    string
 }
 
 // Option for configuring the Command, primarily exists for testing
 type Option func(*Command)
+
+func WithDockerClient(client *docker.Docker) Option {
+	return func(c *Command) {
+		c.docker = client
+	}
+}
 
 // WithTelemetryClient define the telemetry client for this command.
 func WithTelemetryClient(client telemetry.Client) Option {
@@ -99,12 +87,6 @@ func WithBrowserLauncher(launcher BrowserLauncher) Option {
 	}
 }
 
-func WithChartLocator(locator ChartLocator) Option {
-	return func(c *Command) {
-		c.locateChart = locator
-	}
-}
-
 // WithUserHome define the user's home directory.
 func WithUserHome(home string) Option {
 	return func(c *Command) {
@@ -129,10 +111,6 @@ func New(provider k8s.Provider, opts ...Option) (*Command, error) {
 	c := &Command{provider: provider}
 	for _, opt := range opts {
 		opt(c)
-	}
-
-	if c.locateChart == nil {
-		c.locateChart = locateLatestAirbyteChart
 	}
 
 	// determine userhome if not defined
@@ -160,7 +138,7 @@ func New(provider k8s.Provider, opts ...Option) (*Command, error) {
 	// set the helm client, if not defined
 	if c.helm == nil {
 		var err error
-		if c.helm, err = helm.New(provider.Kubeconfig, provider.Context, airbyteNamespace); err != nil {
+		if c.helm, err = helm.New(provider.Kubeconfig, provider.Context, common.AirbyteNamespace); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/cmd/local/local/install_test.go
+++ b/internal/cmd/local/local/install_test.go
@@ -24,13 +24,6 @@ import (
 const portTest = 9999
 const testAirbyteChartLoc = "https://airbytehq.github.io/helm-charts/airbyte-1.2.3.tgz"
 
-func testChartLocator(chartName, chartVersion, chartFlag string) string {
-	if chartName == common.AirbyteChartName && chartVersion == "" {
-		return testAirbyteChartLoc
-	}
-	return chartName
-}
-
 func TestCommand_Install(t *testing.T) {
 	valuesYaml := mustReadFile(t, "testdata/test-edition.values.yaml")
 	expChartRepoCnt := 0
@@ -164,14 +157,16 @@ func TestCommand_Install(t *testing.T) {
 		WithBrowserLauncher(func(url string) error {
 			return nil
 		}),
-		WithChartLocator(testChartLocator),
 	)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	installOpts := &InstallOpts{HelmValuesYaml: valuesYaml}
+	installOpts := &InstallOpts{
+		HelmValuesYaml: valuesYaml,
+		AirbyteChartLoc: testAirbyteChartLoc,
+	}
 	if err := c.Install(context.Background(), installOpts); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cmd/local/local/install_test.go
+++ b/internal/cmd/local/local/install_test.go
@@ -4,83 +4,72 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/airbytehq/abctl/internal/cmd/local/helm"
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s/k8stest"
+	"github.com/airbytehq/abctl/internal/common"
+	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/uuid"
 	helmclient "github.com/mittwald/go-helm-client"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/repo"
-	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
 )
 
 const portTest = 9999
 const testAirbyteChartLoc = "https://airbytehq.github.io/helm-charts/airbyte-1.2.3.tgz"
 
 func testChartLocator(chartName, chartVersion, chartFlag string) string {
-	if chartName == airbyteChartName && chartVersion == "" {
+	if chartName == common.AirbyteChartName && chartVersion == "" {
 		return testAirbyteChartLoc
 	}
 	return chartName
 }
 
 func TestCommand_Install(t *testing.T) {
-	expNginxValues, _ := getNginxValuesYaml(9999)
+	valuesYaml := mustReadFile(t, "testdata/test-edition.values.yaml")
 	expChartRepoCnt := 0
 	expChartRepo := []struct {
 		name string
 		url  string
 	}{
-		{name: airbyteRepoName, url: airbyteRepoURL},
-		{name: nginxRepoName, url: nginxRepoURL},
+		{name: common.AirbyteRepoName, url: common.AirbyteRepoURL},
+		{name: common.NginxRepoName, url: common.NginxRepoURL},
 	}
 
-	// userID is for telemetry tracking purposes
-	userID := uuid.New()
-
 	expChartCnt := 0
+	expNginxValues, _ := helm.BuildNginxValues(9999)
 	expChart := []struct {
 		chart   helmclient.ChartSpec
 		release release.Release
 	}{
 		{
 			chart: helmclient.ChartSpec{
-				ReleaseName:     airbyteChartRelease,
+				ReleaseName:     common.AirbyteChartRelease,
 				ChartName:       testAirbyteChartLoc,
-				Namespace:       airbyteNamespace,
+				Namespace:       common.AirbyteNamespace,
 				CreateNamespace: true,
 				Wait:            true,
 				Timeout:         60 * time.Minute,
-				ValuesYaml: `global:
-    auth:
-        enabled: "true"
-    env_vars:
-        AIRBYTE_INSTALLATION_ID: ` + userID.String() + `
-    jobs:
-        resources:
-            limits:
-                cpu: "3"
-                memory: 4Gi
-`,
+				ValuesYaml:      valuesYaml,
 			},
 			release: release.Release{
 				Chart:     &chart.Chart{Metadata: &chart.Metadata{Version: "1.2.3.4"}},
-				Name:      airbyteChartRelease,
-				Namespace: airbyteNamespace,
+				Name:      common.AirbyteChartRelease,
+				Namespace: common.AirbyteNamespace,
 				Version:   0,
 			},
 		},
 		{
 			chart: helmclient.ChartSpec{
-				ReleaseName:     nginxChartRelease,
-				ChartName:       nginxChartName,
-				Namespace:       nginxNamespace,
+				ReleaseName:     common.NginxChartRelease,
+				ChartName:       common.NginxChartName,
+				Namespace:       common.NginxNamespace,
 				CreateNamespace: true,
 				Wait:            true,
 				Timeout:         60 * time.Minute,
@@ -88,12 +77,13 @@ func TestCommand_Install(t *testing.T) {
 			},
 			release: release.Release{
 				Chart:     &chart.Chart{Metadata: &chart.Metadata{Version: "4.3.2.1"}},
-				Name:      nginxChartRelease,
-				Namespace: nginxNamespace,
+				Name:      common.NginxChartRelease,
+				Namespace: common.NginxNamespace,
 				Version:   0,
 			},
 		},
 	}
+
 	helm := mockHelmClient{
 		addOrUpdateChartRepo: func(entry repo.Entry) error {
 			if d := cmp.Diff(expChartRepo[expChartRepoCnt].name, entry.Name); d != "" {
@@ -112,7 +102,7 @@ func TestCommand_Install(t *testing.T) {
 			switch {
 			case name == testAirbyteChartLoc:
 				return &chart.Chart{Metadata: &chart.Metadata{Version: "test.airbyte.version"}}, "", nil
-			case name == nginxChartName:
+			case name == common.NginxChartName:
 				return &chart.Chart{Metadata: &chart.Metadata{Version: "test.nginx.version"}}, "", nil
 			default:
 				t.Error("unsupported chart name", name)
@@ -122,10 +112,10 @@ func TestCommand_Install(t *testing.T) {
 
 		getRelease: func(name string) (*release.Release, error) {
 			switch {
-			case name == airbyteChartRelease:
+			case name == common.AirbyteChartRelease:
 				t.Error("should not have been called", name)
 				return nil, errors.New("should not have been called")
-			case name == nginxChartRelease:
+			case name == common.NginxChartRelease:
 				return nil, errors.New("not found")
 			default:
 				t.Error("unsupported chart name", name)
@@ -153,25 +143,12 @@ func TestCommand_Install(t *testing.T) {
 	}
 
 	k8sClient := k8stest.MockClient{
-		FnServerVersionGet: func() (string, error) {
-			return "test", nil
-		},
-		FnSecretCreateOrUpdate: func(ctx context.Context, secret corev1.Secret) error {
-			return nil
-		},
 		FnIngressExists: func(ctx context.Context, namespace string, ingress string) bool {
 			return false
 		},
-		FnIngressCreate: func(ctx context.Context, namespace string, ingress *networkingv1.Ingress) error {
-			return nil
-		},
 	}
 
-	attrs := map[string]string{}
-	tel := mockTelemetryClient{
-		attr: func(key, val string) { attrs[key] = val },
-		user: func() uuid.UUID { return userID },
-	}
+	tel := telemetry.MockClient{}
 
 	httpClient := mockHTTP{do: func(req *http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: 200}, nil
@@ -194,182 +171,16 @@ func TestCommand_Install(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := c.Install(context.Background(), InstallOpts{}); err != nil {
+	installOpts := &InstallOpts{HelmValuesYaml: valuesYaml}
+	if err := c.Install(context.Background(), installOpts); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestCommand_Install_HelmValues(t *testing.T) {
-	expChartRepoCnt := 0
-	expChartRepo := []struct {
-		name string
-		url  string
-	}{
-		{name: airbyteRepoName, url: airbyteRepoURL},
-		{name: nginxRepoName, url: nginxRepoURL},
-	}
-
-	// userID is for telemetry tracking purposes
-	userID := uuid.New()
-
-	expChartCnt := 0
-	expNginxValues, _ := getNginxValuesYaml(9999)
-	expChart := []struct {
-		chart   helmclient.ChartSpec
-		release release.Release
-	}{
-		{
-			chart: helmclient.ChartSpec{
-				ReleaseName:     airbyteChartRelease,
-				ChartName:       testAirbyteChartLoc,
-				Namespace:       airbyteNamespace,
-				CreateNamespace: true,
-				Wait:            true,
-				Timeout:         60 * time.Minute,
-				ValuesYaml: `global:
-    auth:
-        enabled: "true"
-    edition: test
-    env_vars:
-        AIRBYTE_INSTALLATION_ID: ` + userID.String() + `
-    jobs:
-        resources:
-            limits:
-                cpu: "3"
-                memory: 4Gi
-`,
-			},
-			release: release.Release{
-				Chart:     &chart.Chart{Metadata: &chart.Metadata{Version: "1.2.3.4"}},
-				Name:      airbyteChartRelease,
-				Namespace: airbyteNamespace,
-				Version:   0,
-			},
-		},
-		{
-			chart: helmclient.ChartSpec{
-				ReleaseName:     nginxChartRelease,
-				ChartName:       nginxChartName,
-				Namespace:       nginxNamespace,
-				CreateNamespace: true,
-				Wait:            true,
-				Timeout:         60 * time.Minute,
-				ValuesYaml:      expNginxValues,
-			},
-			release: release.Release{
-				Chart:     &chart.Chart{Metadata: &chart.Metadata{Version: "4.3.2.1"}},
-				Name:      nginxChartRelease,
-				Namespace: nginxNamespace,
-				Version:   0,
-			},
-		},
-	}
-	helm := mockHelmClient{
-		addOrUpdateChartRepo: func(entry repo.Entry) error {
-			if d := cmp.Diff(expChartRepo[expChartRepoCnt].name, entry.Name); d != "" {
-				t.Error("chart name mismatch", d)
-			}
-			if d := cmp.Diff(expChartRepo[expChartRepoCnt].url, entry.URL); d != "" {
-				t.Error("chart url mismatch", d)
-			}
-
-			expChartRepoCnt++
-
-			return nil
-		},
-
-		getChart: func(name string, _ *action.ChartPathOptions) (*chart.Chart, string, error) {
-			switch {
-			case name == testAirbyteChartLoc:
-				return &chart.Chart{Metadata: &chart.Metadata{Version: "test.airbyte.version"}}, "", nil
-			case name == nginxChartName:
-				return &chart.Chart{Metadata: &chart.Metadata{Version: "test.nginx.version"}}, "", nil
-			default:
-				t.Error("unsupported chart name", name)
-				return nil, "", errors.New("unexpected chart name")
-			}
-		},
-
-		getRelease: func(name string) (*release.Release, error) {
-			switch {
-			case name == airbyteChartRelease:
-				t.Error("should not have been called", name)
-				return nil, errors.New("should not have been called")
-			case name == nginxChartRelease:
-				return nil, errors.New("not found")
-			default:
-				t.Error("unsupported chart name", name)
-				return nil, errors.New("unexpected chart name")
-			}
-		},
-
-		installOrUpgradeChart: func(ctx context.Context, spec *helmclient.ChartSpec, opts *helmclient.GenericHelmOptions) (*release.Release, error) {
-			if d := cmp.Diff(&expChart[expChartCnt].chart, spec); d != "" {
-				t.Error("chart mismatch", d)
-			}
-
-			defer func() { expChartCnt++ }()
-
-			return &expChart[expChartCnt].release, nil
-		},
-
-		uninstallReleaseByName: func(s string) error {
-			if d := cmp.Diff(expChart[expChartCnt].release.Name, s); d != "" {
-				t.Error("release mismatch", d)
-			}
-
-			return nil
-		},
-	}
-
-	k8sClient := k8stest.MockClient{
-		FnServerVersionGet: func() (string, error) {
-			return "test", nil
-		},
-		FnSecretCreateOrUpdate: func(ctx context.Context, secret corev1.Secret) error {
-			return nil
-		},
-		FnIngressExists: func(ctx context.Context, namespace string, ingress string) bool {
-			return false
-		},
-		FnIngressCreate: func(ctx context.Context, namespace string, ingress *networkingv1.Ingress) error {
-			return nil
-		},
-	}
-
-	attrs := map[string]string{}
-	tel := mockTelemetryClient{
-		attr: func(key, val string) { attrs[key] = val },
-		user: func() uuid.UUID { return userID },
-	}
-
-	httpClient := mockHTTP{do: func(req *http.Request) (*http.Response, error) {
-		return &http.Response{StatusCode: 200}, nil
-	}}
-
-	c, err := New(
-		k8s.TestProvider,
-		WithPortHTTP(portTest),
-		WithHelmClient(&helm),
-		WithK8sClient(&k8sClient),
-		WithTelemetryClient(&tel),
-		WithHTTPClient(&httpClient),
-		WithBrowserLauncher(func(url string) error {
-			return nil
-		}),
-		WithChartLocator(testChartLocator),
-	)
-
+func mustReadFile(t *testing.T, name string) string {
+	b, err := os.ReadFile(name)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	helmValues := map[string]any{
-		"global": map[string]any{
-			"edition": "test",
-		},
-	}
-	if err := c.Install(context.Background(), InstallOpts{HelmValues: helmValues}); err != nil {
-		t.Fatal(err)
-	}
+	return string(b)
 }

--- a/internal/cmd/local/local/mock_test.go
+++ b/internal/cmd/local/local/mock_test.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 
 	"github.com/airbytehq/abctl/internal/cmd/local/helm"
-	"github.com/airbytehq/abctl/internal/telemetry"
-	"github.com/google/uuid"
 	helmclient "github.com/mittwald/go-helm-client"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -47,44 +45,8 @@ func (m *mockHelmClient) UninstallReleaseByName(s string) error {
 	return m.uninstallReleaseByName(s)
 }
 
-var _ telemetry.Client = (*mockTelemetryClient)(nil)
-
-type mockTelemetryClient struct {
-	start   func(context.Context, telemetry.EventType) error
-	success func(context.Context, telemetry.EventType) error
-	failure func(context.Context, telemetry.EventType, error) error
-	attr    func(key, val string)
-	user    func() uuid.UUID
-	wrap    func(context.Context, telemetry.EventType, func() error) error
-}
-
-func (m *mockTelemetryClient) Start(ctx context.Context, eventType telemetry.EventType) error {
-	return m.start(ctx, eventType)
-}
-
-func (m *mockTelemetryClient) Success(ctx context.Context, eventType telemetry.EventType) error {
-	return m.success(ctx, eventType)
-}
-
-func (m *mockTelemetryClient) Failure(ctx context.Context, eventType telemetry.EventType, err error) error {
-	return m.failure(ctx, eventType, err)
-}
-
-func (m *mockTelemetryClient) Attr(key, val string) {
-	if m.attr != nil {
-		m.attr(key, val)
-	}
-}
-
-func (m *mockTelemetryClient) User() uuid.UUID {
-	if m.user == nil {
-		return uuid.Nil
-	}
-	return m.user()
-}
-
-func (m *mockTelemetryClient) Wrap(ctx context.Context, et telemetry.EventType, f func() error) error {
-	return m.wrap(ctx, et, f)
+func (m *mockHelmClient) TemplateChart(spec *helmclient.ChartSpec, options *helmclient.HelmTemplateOptions) ([]byte, error) {
+	return nil, nil
 }
 
 var _ HTTPClient = (*mockHTTP)(nil)

--- a/internal/cmd/local/local/specs.go
+++ b/internal/cmd/local/local/specs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/airbytehq/abctl/internal/common"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -36,8 +37,8 @@ func ingress(hosts []string) *networkingv1.Ingress {
 	return &networkingv1.Ingress{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      airbyteIngress,
-			Namespace: airbyteNamespace,
+			Name:      common.AirbyteIngress,
+			Namespace: common.AirbyteNamespace,
 		},
 		Spec: networkingv1.IngressSpec{
 			IngressClassName: &ingressClassName,
@@ -60,7 +61,7 @@ func ingressRule(host string) networkingv1.IngressRule {
 						PathType: &pathType,
 						Backend: networkingv1.IngressBackend{
 							Service: &networkingv1.IngressServiceBackend{
-								Name: fmt.Sprintf("%s-airbyte-webapp-svc", airbyteChartRelease),
+								Name: fmt.Sprintf("%s-airbyte-webapp-svc", common.AirbyteChartRelease),
 								Port: networkingv1.ServiceBackendPort{
 									Name: "http",
 								},

--- a/internal/cmd/local/local/status.go
+++ b/internal/cmd/local/local/status.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/airbytehq/abctl/internal/common"
 	"github.com/pterm/pterm"
 )
 
 // Status handles the status of local Airbyte.
 func (c *Command) Status(_ context.Context) error {
-	charts := []string{airbyteChartRelease, nginxChartRelease}
+	charts := []string{common.AirbyteChartRelease, common.NginxChartRelease}
 	for _, name := range charts {
 		c.spinner.UpdateText(fmt.Sprintf("Verifying %s Helm Chart installation status", name))
 

--- a/internal/cmd/local/local/testdata/expected-default.values.yaml
+++ b/internal/cmd/local/local/testdata/expected-default.values.yaml
@@ -1,0 +1,10 @@
+global:
+    auth:
+        enabled: "true"
+    env_vars:
+        AIRBYTE_INSTALLATION_ID: test-user
+    jobs:
+        resources:
+            limits:
+                cpu: "3"
+                memory: 4Gi

--- a/internal/cmd/local/local/testdata/invalid.values.yaml
+++ b/internal/cmd/local/local/testdata/invalid.values.yaml
@@ -1,0 +1,3 @@
+foo:
+  - bar: baz
+    - foo

--- a/internal/cmd/local/local/testdata/test-edition.values.yaml
+++ b/internal/cmd/local/local/testdata/test-edition.values.yaml
@@ -1,0 +1,2 @@
+global:
+  edition: test

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/airbytehq/abctl/internal/cmd/local/helm"
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
 	"github.com/airbytehq/abctl/internal/cmd/local/local"
-	"github.com/airbytehq/abctl/internal/maps"
+	"github.com/airbytehq/abctl/internal/common"
 
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/pterm/pterm"
@@ -31,6 +32,56 @@ type InstallCmd struct {
 	Volume          []string `help:"Additional volume mounts. Must be in the format <HOST_PATH>:<GUEST_PATH>."`
 }
 
+func (i *InstallCmd) InstallOpts(user string) (*local.InstallOpts, error) {
+	extraVolumeMounts, err := parseVolumeMounts(i.Volume)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, host := range i.Host {
+		if err := validateHostFlag(host); err != nil {
+			return nil, err
+		}
+	}
+
+	opts := &local.InstallOpts{
+		HelmChartVersion:  i.ChartVersion,
+		AirbyteChartLoc:   helm.LocateLatestAirbyteChart(i.ChartVersion, i.Chart),
+		Secrets:           i.Secret,
+		Migrate:           i.Migrate,
+		Hosts:             i.Host,
+		ExtraVolumeMounts: extraVolumeMounts,
+		DockerServer:      i.DockerServer,
+		DockerUser:        i.DockerUsername,
+		DockerPass:        i.DockerPassword,
+		DockerEmail:       i.DockerEmail,
+		NoBrowser:         i.NoBrowser,
+	}
+
+	valuesOpts := helm.ValuesOpts{
+		ValuesFile:      i.Values,
+		InsecureCookies: i.InsecureCookies,
+		LowResourceMode: i.LowResourceMode,
+	}
+
+	if opts.DockerAuth() {
+		valuesOpts.ImagePullSecret = common.DockerAuthSecretName
+	}
+
+	// only override the empty telUser if the tel.User returns a non-nil (uuid.Nil) value.
+	if user != "" {
+		valuesOpts.TelemetryUser = user
+	}
+
+	valuesYAML, err := helm.BuildAirbyteValues(valuesOpts)
+	if err != nil {
+		return nil, err
+	}
+	opts.HelmValuesYaml = valuesYAML
+
+	return opts, nil
+}
+
 func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient telemetry.Client) error {
 	spinner := &pterm.DefaultSpinner
 	spinner, _ = spinner.Start("Starting installation")
@@ -42,20 +93,9 @@ func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient t
 		return fmt.Errorf("unable to determine docker installation status: %w", err)
 	}
 
-	helmValues, err := maps.FromYAMLFile(i.Values)
+	opts, err := i.InstallOpts(telClient.User())
 	if err != nil {
 		return err
-	}
-
-	extraVolumeMounts, err := parseVolumeMounts(i.Volume)
-	if err != nil {
-		return err
-	}
-
-	for _, host := range i.Host {
-		if err := validateHostFlag(host); err != nil {
-			return err
-		}
 	}
 
 	return telClient.Wrap(ctx, telemetry.Install, func() error {
@@ -97,7 +137,7 @@ func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient t
 			pterm.Success.Printfln("Port %d appears to be available", i.Port)
 			spinner.UpdateText(fmt.Sprintf("Creating cluster '%s'", provider.ClusterName))
 
-			if err := cluster.Create(i.Port, extraVolumeMounts); err != nil {
+			if err := cluster.Create(i.Port, opts.ExtraVolumeMounts); err != nil {
 				pterm.Error.Printfln("Cluster '%s' could not be created", provider.ClusterName)
 				return err
 			}
@@ -108,29 +148,11 @@ func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient t
 			local.WithPortHTTP(i.Port),
 			local.WithTelemetryClient(telClient),
 			local.WithSpinner(spinner),
+			local.WithDockerClient(dockerClient),
 		)
 		if err != nil {
 			pterm.Error.Printfln("Failed to initialize 'local' command")
 			return fmt.Errorf("unable to initialize local command: %w", err)
-		}
-
-		opts := local.InstallOpts{
-			HelmChartFlag:    i.Chart,
-			HelmChartVersion: i.ChartVersion,
-			HelmValues:       helmValues,
-			Secrets:          i.Secret,
-			Migrate:          i.Migrate,
-			Docker:           dockerClient,
-			Hosts:            i.Host,
-
-			DockerServer: i.DockerServer,
-			DockerUser:   i.DockerUsername,
-			DockerPass:   i.DockerPassword,
-			DockerEmail:  i.DockerEmail,
-
-			NoBrowser:       i.NoBrowser,
-			LowResourceMode: i.LowResourceMode,
-			InsecureCookies: i.InsecureCookies,
 		}
 
 		if err := lc.Install(ctx, opts); err != nil {
@@ -148,6 +170,10 @@ func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient t
 }
 
 func parseVolumeMounts(specs []string) ([]k8s.ExtraVolumeMount, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+
 	mounts := make([]k8s.ExtraVolumeMount, len(specs))
 
 	for i, spec := range specs {

--- a/internal/cmd/local/local_test.go
+++ b/internal/cmd/local/local_test.go
@@ -152,10 +152,10 @@ func TestInstallOpts(t *testing.T) {
 	b, _ := os.ReadFile("local/testdata/expected-default.values.yaml")
 	cmd := InstallCmd{
 		// Don't let the code dynamically resolve the latest chart version.
-		Chart: "/test/path/to/chart", 
+		Chart: "/test/path/to/chart",
 	}
 	expect := &local.InstallOpts{
-		HelmValuesYaml: string(b),
+		HelmValuesYaml:  string(b),
 		AirbyteChartLoc: "/test/path/to/chart",
 	}
 	opts, err := cmd.InstallOpts("test-user")

--- a/internal/cmd/local/local_test.go
+++ b/internal/cmd/local/local_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
+	"github.com/airbytehq/abctl/internal/cmd/local/local"
 	"github.com/airbytehq/abctl/internal/cmd/local/localerr"
+	"github.com/alecthomas/kong"
 
 	"github.com/airbytehq/abctl/internal/cmd/local/paths"
 	"github.com/airbytehq/abctl/internal/telemetry"
@@ -99,31 +101,27 @@ func TestCheckAirbyteDir(t *testing.T) {
 }
 
 func TestValues_FileDoesntExist(t *testing.T) {
-	cmd := InstallCmd{Values: "thisfiledoesnotexist"}
-	err := cmd.Run(context.Background(), k8s.TestProvider, telemetry.NoopClient{})
+
+	var root InstallCmd
+	k, _ := kong.New(
+		&root,
+		kong.Name("abctl"),
+		kong.Description("Airbyte's command line tool for managing a local Airbyte installation."),
+		kong.UsageOnError(),
+	)
+	_, err := k.Parse([]string{"--values", "/testdata/thisfiledoesnotexist"})
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	expect := "failed to read file thisfiledoesnotexist: open thisfiledoesnotexist: no such file or directory"
+	expect := "--values: stat /testdata/thisfiledoesnotexist: no such file or directory"
 	if err.Error() != expect {
 		t.Errorf("expected %q but got %q", expect, err)
 	}
 }
 
 func TestValues_BadYaml(t *testing.T) {
-	tmpdir := t.TempDir()
-	p := filepath.Join(tmpdir, "values.yaml")
-	content := `
-foo:
-  - bar: baz
-    - foo
-`
 
-	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	cmd := InstallCmd{Values: p}
+	cmd := InstallCmd{Values: "./local/testdata/invalid.values.yaml"}
 	err := cmd.Run(context.Background(), k8s.TestProvider, telemetry.NoopClient{})
 	if err == nil {
 		t.Fatal("expected error")
@@ -131,7 +129,6 @@ foo:
 
 	if !strings.HasPrefix(err.Error(), "failed to unmarshal file") {
 		t.Errorf("unexpected error: %v", err)
-
 	}
 }
 
@@ -148,5 +145,24 @@ func TestInvalidHostFlag_IpAddrWithPort(t *testing.T) {
 	err := cmd.Run(context.Background(), k8s.TestProvider, telemetry.NoopClient{})
 	if !errors.Is(err, localerr.ErrInvalidHostFlag) {
 		t.Errorf("expected ErrInvalidHostFlag but got %v", err)
+	}
+}
+
+func TestInstallOpts(t *testing.T) {
+	b, _ := os.ReadFile("local/testdata/expected-default.values.yaml")
+	cmd := InstallCmd{
+		// Don't let the code dynamically resolve the latest chart version.
+		Chart: "/test/path/to/chart", 
+	}
+	expect := &local.InstallOpts{
+		HelmValuesYaml: string(b),
+		AirbyteChartLoc: "/test/path/to/chart",
+	}
+	opts, err := cmd.InstallOpts("test-user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d := cmp.Diff(expect, opts); d != "" {
+		t.Errorf("unexpected error diff (-want +got):\n%s", d)
 	}
 }

--- a/internal/common/const.go
+++ b/internal/common/const.go
@@ -1,0 +1,19 @@
+package common
+
+const (
+	AirbyteBootloaderPodName = "airbyte-abctl-airbyte-bootloader"
+	AirbyteChartName         = "airbyte/airbyte"
+	AirbyteChartRelease      = "airbyte-abctl"
+	AirbyteIngress           = "ingress-abctl"
+	AirbyteNamespace         = "airbyte-abctl"
+	AirbyteRepoName          = "airbyte"
+	AirbyteRepoURL           = "https://airbytehq.github.io/helm-charts"
+	NginxChartName           = "nginx/ingress-nginx"
+	NginxChartRelease        = "ingress-nginx"
+	NginxNamespace           = "ingress-nginx"
+	NginxRepoName            = "nginx"
+	NginxRepoURL             = "https://kubernetes.github.io/ingress-nginx"
+
+	// DockerAuthSecretName is the name of the secret which holds the docker authentication information.
+	DockerAuthSecretName = "docker-auth"
+)

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/google/uuid"
 	"github.com/pterm/pterm"
 )
 
@@ -43,7 +42,7 @@ type Client interface {
 	// Attr should be called to add additional attributes to this activity.
 	Attr(key, val string)
 	// User returns the user identifier being used by this client
-	User() uuid.UUID
+	User() string
 	// Wrap wraps the func() error with the EventType,
 	// calling the Start, Failure or Success methods correctly based on
 	// the behavior of the func() error

--- a/internal/telemetry/mock.go
+++ b/internal/telemetry/mock.go
@@ -1,0 +1,40 @@
+package telemetry
+
+import "context"
+
+var _ Client = (*MockClient)(nil)
+
+type MockClient struct {
+	attrs   map[string]string
+	start   func(context.Context, EventType) error
+	success func(context.Context, EventType) error
+	failure func(context.Context, EventType, error) error
+	wrap    func(context.Context, EventType, func() error) error
+}
+
+func (m *MockClient) Start(ctx context.Context, eventType EventType) error {
+	return m.start(ctx, eventType)
+}
+
+func (m *MockClient) Success(ctx context.Context, eventType EventType) error {
+	return m.success(ctx, eventType)
+}
+
+func (m *MockClient) Failure(ctx context.Context, eventType EventType, err error) error {
+	return m.failure(ctx, eventType, err)
+}
+
+func (m *MockClient) Attr(key, val string) {
+	if m.attrs == nil {
+		m.attrs = map[string]string{}
+	}
+	m.attrs[key] = val
+}
+
+func (m *MockClient) User() string {
+	return "test-user"
+}
+
+func (m *MockClient) Wrap(ctx context.Context, et EventType, f func() error) error {
+	return m.wrap(ctx, et, f)
+}

--- a/internal/telemetry/noop.go
+++ b/internal/telemetry/noop.go
@@ -2,8 +2,6 @@ package telemetry
 
 import (
 	"context"
-
-	"github.com/google/uuid"
 )
 
 var _ Client = (*NoopClient)(nil)
@@ -26,8 +24,8 @@ func (n NoopClient) Failure(context.Context, EventType, error) error {
 
 func (n NoopClient) Attr(_, _ string) {}
 
-func (n NoopClient) User() uuid.UUID {
-	return uuid.Nil
+func (n NoopClient) User() string {
+	return ""
 }
 
 func (n NoopClient) Wrap(ctx context.Context, et EventType, f func() error) error {

--- a/internal/telemetry/noop_test.go
+++ b/internal/telemetry/noop_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/uuid"
 )
 
 func TestNoopClient(t *testing.T) {
@@ -25,7 +24,7 @@ func TestNoopClient(t *testing.T) {
 
 	cli.Attr("k", "v'")
 
-	if d := cmp.Diff(uuid.Nil, cli.User()); d != "" {
+	if d := cmp.Diff("", cli.User()); d != "" {
 		t.Errorf("user should be nil (-want +got): %s", d)
 	}
 }

--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -82,8 +82,8 @@ func (s *SegmentClient) Attr(key, val string) {
 	s.attrs[key] = val
 }
 
-func (s *SegmentClient) User() uuid.UUID {
-	return s.cfg.AnalyticsID.toUUID()
+func (s *SegmentClient) User() string {
+	return s.cfg.AnalyticsID.toUUID().String()
 }
 
 func (s *SegmentClient) Wrap(ctx context.Context, et EventType, f func() error) error {


### PR DESCRIPTION
https://github.com/airbytehq/airbyte-internal-issues/issues/10018

This adds `abctl images manifest` which prints a list of container images used by the Airbyte platform.

```
abctl git:(abuch/images-cmd) ./abctl images manifest
airbyte/bootloader:1.1.0
airbyte/connector-builder-server:1.1.0
airbyte/cron:1.1.0
airbyte/db:1.1.0
airbyte/mc
airbyte/server:1.1.0
airbyte/webapp:1.1.0
airbyte/worker:1.1.0
airbyte/workload-api-server:1.1.0
airbyte/workload-launcher:1.1.0
bitnami/kubectl:1.28.9
busybox
minio/minio:RELEASE.2023-11-20T22-40-07Z
temporalio/auto-setup:1.23.0
```

It takes `--chart`, `--chart-version`, and `--values` flags (similar to `local install`) which can affect the outcome. For example, if you're `values.yaml` configures the enterprise edition, the image manifest will include keycloak and any other enterprise-specific images.

I needed to refactor some code in order to share Helm functions between the `install` and `images` commands. In particular, I've pulled a lot of Helm values building up into `BuildAirbyteValues` and `InstallCmd.InstallOpts()`. I also pulled some shared contants into a new `common` package.

I deduped the `mockTelemetryClient` into `telemetry.MockClient` and simplified it a bit, so the test code using this is simpler. I refactored `telemetry.Client.User() UUID` to `telemetry.Client.User() string` (segment still uses a UUID behind the scenes of course, it's just not exposed in the Go interface anymore).

Testing the manifest command involves pulling down actual charts (1.1.0 and a recent nightly version). This is _somewhat_ lame, but without this the test wouldn't actually test much.