### PR TITLE
fix: set sentry env

### DIFF
--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -88,6 +88,7 @@ func Init(ctx context.Context) ([]Shutdown, error) {
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn:                dsn,
 		EnableTracing:      true,
+		Environment:        "public",
 		Release:            build.Version,
 		TracesSampleRate:   1.0,
 		ProfilesSampleRate: 1.0,


### PR DESCRIPTION
- sentry ui doesn't like it when no env is set
    - or at least it is inconsistent with its behavior