### PR TITLE
fix: don't pass context to segment telemetry

### DIFF
--- a/internal/cmd/local/local/install.go
+++ b/internal/cmd/local/local/install.go
@@ -182,7 +182,7 @@ func (c *Command) Install(ctx context.Context, opts *InstallOpts) error {
 	span.SetAttributes(attribute.Bool("migrate", opts.Migrate))
 	if opts.Migrate {
 		c.spinner.UpdateText("Migrating airbyte data")
-		if err := c.tel.Wrap(ctx, telemetry.Migrate, func() error { return migrate.FromDockerVolume(ctx, c.docker.Client, "airbyte_db") }); err != nil {
+		if err := c.tel.Wrap(telemetry.Migrate, func() error { return migrate.FromDockerVolume(ctx, c.docker.Client, "airbyte_db") }); err != nil {
 			pterm.Error.Println("Failed to migrate data from previous Airbyte installation")
 			return fmt.Errorf("unable to migrate data from previous airbyte installation: %w", err)
 		}

--- a/internal/cmd/local/local_credentials.go
+++ b/internal/cmd/local/local_credentials.go
@@ -34,7 +34,7 @@ func (cc *CredentialsCmd) Run(ctx context.Context, provider k8s.Provider, telCli
 
 	spinner := &pterm.DefaultSpinner
 
-	return telClient.Wrap(ctx, telemetry.Credentials, func() error {
+	return telClient.Wrap(telemetry.Credentials, func() error {
 		k8sClient, err := defaultK8s(provider.Kubeconfig, provider.Context)
 		if err != nil {
 			pterm.Error.Println("No existing cluster found")

--- a/internal/cmd/local/local_deployments.go
+++ b/internal/cmd/local/local_deployments.go
@@ -23,7 +23,7 @@ func (d *DeploymentsCmd) Run(ctx context.Context, telClient telemetry.Client, k8
 		return err
 	}
 
-	return telClient.Wrap(ctx, telemetry.Deployments, func() error {
+	return telClient.Wrap(telemetry.Deployments, func() error {
 		return d.deployments(ctx, k8sClient, spinner)
 	})
 }

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -107,7 +107,7 @@ func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient t
 		return err
 	}
 
-	return telClient.Wrap(ctx, telemetry.Install, func() error {
+	return telClient.Wrap(telemetry.Install, func() error {
 		spinner.UpdateText(fmt.Sprintf("Checking for existing Kubernetes cluster '%s'", provider.ClusterName))
 
 		cluster, err := provider.Cluster(ctx)

--- a/internal/cmd/local/local_status.go
+++ b/internal/cmd/local/local_status.go
@@ -22,7 +22,7 @@ func (s *StatusCmd) Run(ctx context.Context, provider k8s.Provider, telClient te
 		return err
 	}
 
-	return telClient.Wrap(ctx, telemetry.Status, func() error {
+	return telClient.Wrap(telemetry.Status, func() error {
 		return status(ctx, provider, telClient, spinner)
 	})
 }

--- a/internal/cmd/local/local_uninstall.go
+++ b/internal/cmd/local/local_uninstall.go
@@ -32,7 +32,7 @@ func (u *UninstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient
 		return fmt.Errorf("unable to determine docker installation status: %w", err)
 	}
 
-	return telClient.Wrap(ctx, telemetry.Uninstall, func() error {
+	return telClient.Wrap(telemetry.Uninstall, func() error {
 		spinner.UpdateText(fmt.Sprintf("Checking for existing Kubernetes cluster '%s'", provider.ClusterName))
 
 		cluster, err := provider.Cluster(ctx)

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -1,7 +1,6 @@
 package telemetry
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -34,11 +33,11 @@ const (
 // Client interface for telemetry data.
 type Client interface {
 	// Start should be called as quickly as possible.
-	Start(context.Context, EventType) error
+	Start(EventType) error
 	// Success should be called only if the activity succeeded.
-	Success(context.Context, EventType) error
+	Success(EventType) error
 	// Failure should be called only if the activity failed.
-	Failure(context.Context, EventType, error) error
+	Failure(EventType, error) error
 	// Attr should be called to add additional attributes to this activity.
 	Attr(key, val string)
 	// User returns the user identifier being used by this client
@@ -46,7 +45,7 @@ type Client interface {
 	// Wrap wraps the func() error with the EventType,
 	// calling the Start, Failure or Success methods correctly based on
 	// the behavior of the func() error
-	Wrap(context.Context, EventType, func() error) error
+	Wrap(EventType, func() error) error
 }
 
 type getConfig struct {

--- a/internal/telemetry/mock.go
+++ b/internal/telemetry/mock.go
@@ -1,27 +1,25 @@
 package telemetry
 
-import "context"
-
 var _ Client = (*MockClient)(nil)
 
 type MockClient struct {
 	attrs   map[string]string
-	start   func(context.Context, EventType) error
-	success func(context.Context, EventType) error
-	failure func(context.Context, EventType, error) error
-	wrap    func(context.Context, EventType, func() error) error
+	start   func(EventType) error
+	success func(EventType) error
+	failure func(EventType, error) error
+	wrap    func(EventType, func() error) error
 }
 
-func (m *MockClient) Start(ctx context.Context, eventType EventType) error {
-	return m.start(ctx, eventType)
+func (m *MockClient) Start(eventType EventType) error {
+	return m.start(eventType)
 }
 
-func (m *MockClient) Success(ctx context.Context, eventType EventType) error {
-	return m.success(ctx, eventType)
+func (m *MockClient) Success(eventType EventType) error {
+	return m.success(eventType)
 }
 
-func (m *MockClient) Failure(ctx context.Context, eventType EventType, err error) error {
-	return m.failure(ctx, eventType, err)
+func (m *MockClient) Failure(eventType EventType, err error) error {
+	return m.failure(eventType, err)
 }
 
 func (m *MockClient) Attr(key, val string) {
@@ -35,6 +33,6 @@ func (m *MockClient) User() string {
 	return "test-user"
 }
 
-func (m *MockClient) Wrap(ctx context.Context, et EventType, f func() error) error {
-	return m.wrap(ctx, et, f)
+func (m *MockClient) Wrap(et EventType, f func() error) error {
+	return m.wrap(et, f)
 }

--- a/internal/telemetry/noop.go
+++ b/internal/telemetry/noop.go
@@ -1,24 +1,20 @@
 package telemetry
 
-import (
-	"context"
-)
-
 var _ Client = (*NoopClient)(nil)
 
 // NoopClient client, all methods are no-ops.
 type NoopClient struct {
 }
 
-func (n NoopClient) Start(context.Context, EventType) error {
+func (n NoopClient) Start(EventType) error {
 	return nil
 }
 
-func (n NoopClient) Success(context.Context, EventType) error {
+func (n NoopClient) Success(EventType) error {
 	return nil
 }
 
-func (n NoopClient) Failure(context.Context, EventType, error) error {
+func (n NoopClient) Failure(EventType, error) error {
 	return nil
 }
 
@@ -28,6 +24,6 @@ func (n NoopClient) User() string {
 	return ""
 }
 
-func (n NoopClient) Wrap(ctx context.Context, et EventType, f func() error) error {
+func (n NoopClient) Wrap(et EventType, f func() error) error {
 	return f()
 }

--- a/internal/telemetry/noop_test.go
+++ b/internal/telemetry/noop_test.go
@@ -1,7 +1,6 @@
 package telemetry
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -11,14 +10,13 @@ import (
 
 func TestNoopClient(t *testing.T) {
 	cli := NoopClient{}
-	ctx := context.Background()
-	if err := cli.Start(ctx, Install); err != nil {
+	if err := cli.Start(Install); err != nil {
 		t.Error(err)
 	}
-	if err := cli.Success(ctx, Install); err != nil {
+	if err := cli.Success(Install); err != nil {
 		t.Error(err)
 	}
-	if err := cli.Failure(ctx, Install, errors.New("")); err != nil {
+	if err := cli.Failure(Install, errors.New("")); err != nil {
 		t.Error(err)
 	}
 
@@ -40,7 +38,7 @@ func TestNoopClient_Wrap(t *testing.T) {
 
 		cli := NoopClient{}
 
-		if err := cli.Wrap(context.Background(), Install, fn); err != nil {
+		if err := cli.Wrap(Install, fn); err != nil {
 			t.Fatal("unexpected error", err)
 		}
 
@@ -59,7 +57,7 @@ func TestNoopClient_Wrap(t *testing.T) {
 
 		cli := NoopClient{}
 
-		err := cli.Wrap(context.Background(), Install, fn)
+		err := cli.Wrap(Install, fn)
 		if d := cmp.Diff(expectedErr, err, cmpopts.EquateErrors()); d != "" {
 			t.Errorf("function should have returned an error (-want, +got): %s", d)
 		}

--- a/internal/telemetry/segment_test.go
+++ b/internal/telemetry/segment_test.go
@@ -1,7 +1,6 @@
 package telemetry
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -56,9 +55,7 @@ func TestSegmentClient_Start(t *testing.T) {
 
 	cli := NewSegmentClient(Config{AnalyticsID: UUID(userID)}, opts...)
 
-	ctx := context.Background()
-
-	if err := cli.Start(ctx, Install); err != nil {
+	if err := cli.Start(Install); err != nil {
 		t.Error("start call failed", err)
 	}
 
@@ -160,9 +157,7 @@ func TestSegmentClient_StartWithAttr(t *testing.T) {
 	cli.Attr("key1", "val1")
 	cli.Attr("key2", "val2")
 
-	ctx := context.Background()
-
-	if err := cli.Start(ctx, Install); err != nil {
+	if err := cli.Start(Install); err != nil {
 		t.Error("start call failed", err)
 	}
 
@@ -267,9 +262,7 @@ func TestSegmentClient_StartErr(t *testing.T) {
 
 	cli := NewSegmentClient(Config{AnalyticsID: UUID(userID)}, opts...)
 
-	ctx := context.Background()
-
-	if err := cli.Start(ctx, Install); err == nil {
+	if err := cli.Start(Install); err == nil {
 		t.Error("start call should have failed")
 	} else if !errors.Is(err, httpErr) {
 		t.Error("start call error should contain http error", err)
@@ -292,9 +285,7 @@ func TestSegmentClient_Success(t *testing.T) {
 
 	cli := NewSegmentClient(Config{AnalyticsID: UUID(userID)}, opts...)
 
-	ctx := context.Background()
-
-	if err := cli.Success(ctx, Install); err != nil {
+	if err := cli.Success(Install); err != nil {
 		t.Error("start call failed", err)
 	}
 
@@ -396,9 +387,7 @@ func TestSegmentClient_SuccessWithAttr(t *testing.T) {
 	cli.Attr("key1", "val1")
 	cli.Attr("key2", "val2")
 
-	ctx := context.Background()
-
-	if err := cli.Success(ctx, Install); err != nil {
+	if err := cli.Success(Install); err != nil {
 		t.Error("start call failed", err)
 	}
 
@@ -503,9 +492,7 @@ func TestSegmentClient_SuccessErr(t *testing.T) {
 
 	cli := NewSegmentClient(Config{AnalyticsID: UUID(userID)}, opts...)
 
-	ctx := context.Background()
-
-	if err := cli.Success(ctx, Install); err == nil {
+	if err := cli.Success(Install); err == nil {
 		t.Error("start call should have failed")
 	} else if !errors.Is(err, httpErr) {
 		t.Error("start call error should contain http error", err)
@@ -528,10 +515,9 @@ func TestSegmentClient_Failure(t *testing.T) {
 
 	cli := NewSegmentClient(Config{AnalyticsID: UUID(userID)}, opts...)
 
-	ctx := context.Background()
 	failure := errors.New("failure reason")
 
-	if err := cli.Failure(ctx, Install, failure); err != nil {
+	if err := cli.Failure(Install, failure); err != nil {
 		t.Error("start call failed", err)
 	}
 
@@ -633,10 +619,9 @@ func TestSegmentClient_FailureWithAttr(t *testing.T) {
 	cli.Attr("key1", "val1")
 	cli.Attr("key2", "val2")
 
-	ctx := context.Background()
 	failure := errors.New("failure reason")
 
-	if err := cli.Failure(ctx, Install, failure); err != nil {
+	if err := cli.Failure(Install, failure); err != nil {
 		t.Error("start call failed", err)
 	}
 
@@ -741,10 +726,9 @@ func TestSegmentClient_FailureErr(t *testing.T) {
 
 	cli := NewSegmentClient(Config{AnalyticsID: UUID(userID)}, opts...)
 
-	ctx := context.Background()
 	failure := errors.New("failure reason")
 
-	if err := cli.Failure(ctx, Install, failure); err == nil {
+	if err := cli.Failure(Install, failure); err == nil {
 		t.Error("start call should have failed")
 	} else if !errors.Is(err, httpErr) {
 		t.Error("start call error should contain http error", err)
@@ -784,11 +768,9 @@ func TestSegmentClient_Wrap(t *testing.T) {
 
 	cli := NewSegmentClient(Config{AnalyticsID: UUID(userID)}, opts...)
 
-	ctx := context.Background()
-
 	// a Wrap call where the func() error doesn't return an error
 	// should call Start and Success
-	if err := cli.Wrap(ctx, Install, func() error { return nil }); err != nil {
+	if err := cli.Wrap(Install, func() error { return nil }); err != nil {
 		t.Error("Wrap call failed")
 	}
 
@@ -839,13 +821,11 @@ func TestSegmentClient_WrapErr(t *testing.T) {
 
 	cli := NewSegmentClient(Config{AnalyticsID: UUID(userID)}, opts...)
 
-	ctx := context.Background()
-
 	actualErr := errors.New("test failure")
 
 	// a Wrap call where the func() error returns asn error
 	// should call Start and Failure
-	err := cli.Wrap(ctx, Uninstall, func() error { return actualErr })
+	err := cli.Wrap(Uninstall, func() error { return actualErr })
 	if d := cmp.Diff(actualErr, err, cmpopts.EquateErrors()); d != "" {
 		t.Errorf("error mismatch (-want +got): %s", err)
 	}


### PR DESCRIPTION
When a user cancels an install by pressing Ctrl+C, the Go Context created in main.go is canceled. That context was being passed to the Segment telemetry client, which was trying to send an HTTP request using the canceled context, which would always fail. That resulted in a surprisingly large number of 'running' events. 

This change removes the context from the telemetry client calls so that this doesn't happen.