### PR TITLE
fix: ignore context in http request to segment

### DIFF
--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -150,7 +150,7 @@ func (s *SegmentClient) send(ctx context.Context, es EventState, et EventType, e
 		return fmt.Errorf("unable to create request body: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(data))
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(data))
 	if err != nil {
 		return fmt.Errorf("unable to create request: %w", err)
 	}


### PR DESCRIPTION
When a user cancels an install by pressing Ctrl+C, the Go Context created in main.go is canceled. That context was being passed to the Segment telemetry client, which was trying to send an HTTP request using the canceled context, which would always fail. That resulted in a surprisingly large number of 'running' events. 

This change removes the context from the telemetry client's http calls so that this doesn't happen.