### PR TITLE
fix: deployments command failing

### DIFF
--- a/internal/cmd/local/local_credentials.go
+++ b/internal/cmd/local/local_credentials.go
@@ -6,12 +6,9 @@ import (
 
 	"github.com/airbytehq/abctl/internal/cmd/local/airbyte"
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
-	"github.com/airbytehq/abctl/internal/cmd/local/localerr"
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/pterm/pterm"
 	"go.opencensus.io/trace"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -105,22 +102,4 @@ func (cc *CredentialsCmd) Run(ctx context.Context, provider k8s.Provider, telCli
   Client-Secret: %s`, orgEmail, secret.Data[secretPassword], clientId, clientSecret))
 		return nil
 	})
-}
-
-func defaultK8s(kubecfg, kubectx string) (k8s.Client, error) {
-	k8sCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubecfg},
-		&clientcmd.ConfigOverrides{CurrentContext: kubectx},
-	)
-
-	restCfg, err := k8sCfg.ClientConfig()
-	if err != nil {
-		return nil, fmt.Errorf("%w: could not create rest config: %w", localerr.ErrKubernetes, err)
-	}
-	k8sClient, err := kubernetes.NewForConfig(restCfg)
-	if err != nil {
-		return nil, fmt.Errorf("%w: could not create clientset: %w", localerr.ErrKubernetes, err)
-	}
-
-	return &k8s.DefaultK8sClient{ClientSet: k8sClient}, nil
 }

--- a/internal/cmd/local/local_deployments.go
+++ b/internal/cmd/local/local_deployments.go
@@ -14,9 +14,14 @@ type DeploymentsCmd struct {
 	Restart string `help:"Deployment to restart."`
 }
 
-func (d *DeploymentsCmd) Run(ctx context.Context, telClient telemetry.Client, k8sClient k8s.Client) error {
+func (d *DeploymentsCmd) Run(ctx context.Context, telClient telemetry.Client, provider k8s.Provider) error {
 	ctx, span := trace.StartSpan(ctx, "local deployments")
 	defer span.End()
+
+	k8sClient, err := defaultK8s(provider.Kubeconfig, provider.Context)
+	if err != nil {
+		return err
+	}
 
 	spinner := &pterm.DefaultSpinner
 	if err := checkDocker(ctx, telClient, spinner); err != nil {


### PR DESCRIPTION
- fix the error `couldn't find binding of type k8s.Client for parameter 2 of func(context.Context, telemetry.Client, k8s.Client) error(), use kong.Bind(k8s.Client)`
    - moved the `defaultK8s` method from `local_credentials` to `local` and called the method from the deployments command 