### PR TITLE
refactor: dedupe defaultK8s func

### DIFF
--- a/internal/cmd/local/local.go
+++ b/internal/cmd/local/local.go
@@ -10,8 +10,6 @@ import (
 	"github.com/airbytehq/abctl/internal/cmd/local/localerr"
 	"github.com/airbytehq/abctl/internal/cmd/local/paths"
 	"github.com/pterm/pterm"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 type Cmd struct {
@@ -73,23 +71,4 @@ func checkAirbyteDir() error {
 	}
 
 	return nil
-}
-
-// defaultK8s returns the default k8s client for the provided kubecfg and kubectx.
-func defaultK8s(kubecfg, kubectx string) (k8s.Client, error) {
-	k8sCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubecfg},
-		&clientcmd.ConfigOverrides{CurrentContext: kubectx},
-	)
-
-	restCfg, err := k8sCfg.ClientConfig()
-	if err != nil {
-		return nil, fmt.Errorf("%w: could not create rest config: %w", localerr.ErrKubernetes, err)
-	}
-	k8sClient, err := kubernetes.NewForConfig(restCfg)
-	if err != nil {
-		return nil, fmt.Errorf("%w: could not create clientset: %w", localerr.ErrKubernetes, err)
-	}
-
-	return &k8s.DefaultK8sClient{ClientSet: k8sClient}, nil
 }

--- a/internal/cmd/local/local_credentials.go
+++ b/internal/cmd/local/local_credentials.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/airbytehq/abctl/internal/cmd/local/airbyte"
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
+	"github.com/airbytehq/abctl/internal/cmd/local/local"
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/pterm/pterm"
 	"go.opencensus.io/trace"
@@ -32,7 +33,7 @@ func (cc *CredentialsCmd) Run(ctx context.Context, provider k8s.Provider, telCli
 	spinner := &pterm.DefaultSpinner
 
 	return telClient.Wrap(ctx, telemetry.Credentials, func() error {
-		k8sClient, err := defaultK8s(provider.Kubeconfig, provider.Context)
+		k8sClient, err := local.DefaultK8s(provider.Kubeconfig, provider.Context)
 		if err != nil {
 			pterm.Error.Println("No existing cluster found")
 			return nil

--- a/internal/cmd/local/local_deployments.go
+++ b/internal/cmd/local/local_deployments.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/airbytehq/abctl/internal/cmd/local/k8s"
+	"github.com/airbytehq/abctl/internal/cmd/local/local"
 	"github.com/airbytehq/abctl/internal/telemetry"
 	"github.com/pterm/pterm"
 	"go.opencensus.io/trace"
@@ -18,7 +19,7 @@ func (d *DeploymentsCmd) Run(ctx context.Context, telClient telemetry.Client, pr
 	ctx, span := trace.StartSpan(ctx, "local deployments")
 	defer span.End()
 
-	k8sClient, err := defaultK8s(provider.Kubeconfig, provider.Context)
+	k8sClient, err := local.DefaultK8s(provider.Kubeconfig, provider.Context)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There were two `defaultK8s` functions. Dedupe them.