### PR TITLE
fix: ensure kubeconfig exists

### DIFF
--- a/internal/cmd/local/k8s/provider.go
+++ b/internal/cmd/local/k8s/provider.go
@@ -35,7 +35,9 @@ func (p Provider) Cluster(ctx context.Context) (Cluster, error) {
 	}
 
 	kindProvider := cluster.NewProvider(cluster.ProviderWithLogger(&kindLogger{pterm: pterm.Debug}))
-	kindProvider.ExportKubeConfig(p.ClusterName, p.Kubeconfig, false)
+	if err := kindProvider.ExportKubeConfig(p.ClusterName, p.Kubeconfig, false); err != nil {
+		pterm.Debug.Printfln("failed to export kube config: %s", err)
+	}
 
 	return &kindCluster{
 		p:          kindProvider,

--- a/internal/cmd/local/k8s/provider.go
+++ b/internal/cmd/local/k8s/provider.go
@@ -29,12 +29,16 @@ type Provider struct {
 func (p Provider) Cluster(ctx context.Context) (Cluster, error) {
 	_, span := trace.NewSpan(ctx, "Provider.Cluster")
 	defer span.End()
+
 	if err := os.MkdirAll(filepath.Dir(p.Kubeconfig), 0766); err != nil {
 		return nil, fmt.Errorf("unable to create directory %s: %v", p.Kubeconfig, err)
 	}
 
+	kindProvider := cluster.NewProvider(cluster.ProviderWithLogger(&kindLogger{pterm: pterm.Debug}))
+	kindProvider.ExportKubeConfig(p.ClusterName, p.Kubeconfig, false)
+
 	return &kindCluster{
-		p:           cluster.NewProvider(cluster.ProviderWithLogger(&kindLogger{pterm: pterm.Debug})),
+		p:          kindProvider,
 		kubeconfig:  p.Kubeconfig,
 		clusterName: p.ClusterName,
 	}, nil

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -120,6 +120,7 @@ func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient t
 			// existing cluster, validate it
 			pterm.Success.Printfln("Existing cluster '%s' found", provider.ClusterName)
 			spinner.UpdateText(fmt.Sprintf("Validating existing cluster '%s'", provider.ClusterName))
+			span.SetAttributes(attribute.Bool("cluster_exists", true))
 
 			// only for kind do we need to check the existing port
 			if provider.Name == k8s.Kind {
@@ -138,6 +139,7 @@ func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient t
 		} else {
 			// no existing cluster, need to create one
 			pterm.Info.Println(fmt.Sprintf("No existing cluster found, cluster '%s' will be created", provider.ClusterName))
+			span.SetAttributes(attribute.Bool("cluster_exists", false))
 
 			spinner.UpdateText(fmt.Sprintf("Checking if port %d is available", i.Port))
 			if err := portAvailable(ctx, i.Port); err != nil {


### PR DESCRIPTION
I'm trying to fix errors like the following, which I see quite often:
```
unable to initialize local command: error communicating with kubernetes: could not create rest config: stat /home/some-user-name/.airbyte/abctl/abctl.kubeconfig: no such file or directory
```

I can reproduce this locally if I
1. `abctl local install`
2. `rm ~/.airbyte/abctl/abctl.kubeconfig`
3. `abctl local install`

Maybe people are removing the `.airbyte/abctl` directory, thinking that will reset some things, or maybe they're moving the kubeconfig file somewhere for easy reference. Anyway, it's easy to make sure it always exists.