### PR TITLE
fix: inspect docker context to find best host

### DIFF
--- a/internal/cmd/local/docker/docker_test.go
+++ b/internal/cmd/local/docker/docker_test.go
@@ -93,17 +93,17 @@ func TestNewWithOptions_InitErr(t *testing.T) {
 		{
 			name:        "darwin",
 			goos:        "darwin",
-			expAttempts: 2, // darwin will attempt two different locations
+			expAttempts: 3,
 		},
 		{
 			name:        "windows",
 			goos:        "windows",
-			expAttempts: 1,
+			expAttempts: 2,
 		},
 		{
 			name:        "linux",
 			goos:        "linux",
-			expAttempts: 1,
+			expAttempts: 3,
 		},
 	}
 


### PR DESCRIPTION
`abctl` isn't handling Docker Desktop on Linux very well. Docker has multiple contexts, and `abctl` is making some guesses about which context to use, but it's often wrong on Docker Desktop on Linux. This is a problem because `kind` will end up using a different context and the user will run into strange errors.

This change execs `docker context inspect`, which describes the current context in detail. If this command fails, it will fail silently, and `abctl` will fall back to its original behavior (guessing at some common host socket locations).

