### PR TITLE
fix: fix log panic

### DIFF
--- a/internal/cmd/local/local/install.go
+++ b/internal/cmd/local/local/install.go
@@ -332,7 +332,11 @@ func (c *Command) diagnoseAirbyteChartFailure(ctx context.Context, chartErr erro
 			if err != nil {
 				msg = "unknown: failed to get pod logs."
 			}
-			pterm.Debug.Println("found logs: ", logs[0:50])
+			preview := logs
+			// if len(preview) > 50 {
+			// 	preview = preview[:50]
+			// }
+			pterm.Debug.Println("found logs: ", preview)
 
 			trace.AttachLog(fmt.Sprintf("%s.log", pod.Name), logs)
 

--- a/internal/cmd/local/local/install.go
+++ b/internal/cmd/local/local/install.go
@@ -332,10 +332,11 @@ func (c *Command) diagnoseAirbyteChartFailure(ctx context.Context, chartErr erro
 			if err != nil {
 				msg = "unknown: failed to get pod logs."
 			}
+			
 			preview := logs
-			// if len(preview) > 50 {
-			// 	preview = preview[:50]
-			// }
+			if len(preview) > 50 {
+				preview = preview[:50]
+			}
 			pterm.Debug.Println("found logs: ", preview)
 
 			trace.AttachLog(fmt.Sprintf("%s.log", pod.Name), logs)

--- a/internal/cmd/local/local/mock_test.go
+++ b/internal/cmd/local/local/mock_test.go
@@ -26,6 +26,9 @@ type mockHelmClient struct {
 }
 
 func (m *mockHelmClient) AddOrUpdateChartRepo(entry repo.Entry) error {
+	if m.addOrUpdateChartRepo == nil {
+		return nil
+	}
 	return m.addOrUpdateChartRepo(entry)
 }
 


### PR DESCRIPTION
Short logs from a pod are causing panics.

This also updates the Segment telemetry `Wrap` function to capture panics and write them to telemetry.