### PR TITLE
fix: attach all logs on chart failure

### DIFF
--- a/internal/cmd/local/local/install_test.go
+++ b/internal/cmd/local/local/install_test.go
@@ -227,7 +227,7 @@ func TestCommand_InstallError(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = c.Install(context.Background(), installOpts)
-	expect := "unable to install airbyte chart:\npod test-pod-1: unknown"
+	expect := "unable to install airbyte chart: unable to install helm: test error"
 	if expect != err.Error() {
 		t.Errorf("expected %q but got %q", expect, err)
 	}

--- a/internal/cmd/local/local/log_utils.go
+++ b/internal/cmd/local/local/log_utils.go
@@ -59,21 +59,3 @@ func (j *logScanner) Scan() bool {
 func (j *logScanner) Err() error {
 	return j.scanner.Err()
 }
-
-func getLastLogError(r io.Reader) (string, error) {
-	var lines []logLine
-	s := newLogScanner(r)
-	for s.Scan() {
-		lines = append(lines, s.line)
-	}
-	if s.Err() != nil {
-		return "", s.Err()
-	}
-
-	for i := len(lines) - 1; i >= 0; i-- {
-		if lines[i].level == "ERROR" {
-			return lines[i].msg, nil
-		}
-	}
-	return "", nil
-}

--- a/internal/cmd/local/local/log_utils_test.go
+++ b/internal/cmd/local/local/log_utils_test.go
@@ -22,27 +22,6 @@ Caused by: io.airbyte.db.check.DatabaseCheckException: Unable to connect to the 
 2024-09-12T15:56:33.125352208Z Thread-4 INFO Loading mask data from '/seed/specs_secrets_mask.yaml
 `)
 
-var testLogs2 = strings.TrimSpace(`
-2024-11-12 20:52:07,403 [main]	[1;31mERROR[0;39m	i.a.d.c.DatabaseAvailabilityCheck(lambda$isDatabaseConnected$1):78 - Failed to verify database connection.
-org.jooq.exception.DataAccessException: Error getting connection from data source HikariDataSource (HikariPool-1)
-	at org.jooq_3.19.7.POSTGRES.debug(Unknown Source)
-	at org.jooq.impl.DataSourceConnectionProvider.acquire(DataSourceConnectionProvider.java:90)
-Caused by: java.sql.SQLTransientConnectionException: HikariPool-1 - Connection is not available, request timed out after 30110ms (total=0, active=0, idle=0, waiting=0)
-	at com.zaxxer.hikari.pool.HikariPool.createTimeoutException(HikariPool.java:686)
-	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:179)
-	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:144)
-	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:99)
-	at org.jooq.impl.DataSourceConnectionProvider.acquire(DataSourceConnectionProvider.java:87)
-	... 22 common frames omitted
-Caused by: org.postgresql.util.PSQLException: The connection attempt failed.
-	at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:364)
-	at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:54)
-Caused by: java.net.UnknownHostException: airbyte-db-svc
-	at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:567)
-	at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:268)
-	... 14 common frames omitted
-`)
-
 func TestJavaLogScanner(t *testing.T) {
 	s := newLogScanner(strings.NewReader(testLogs))
 

--- a/internal/cmd/local/local/log_utils_test.go
+++ b/internal/cmd/local/local/log_utils_test.go
@@ -22,6 +22,27 @@ Caused by: io.airbyte.db.check.DatabaseCheckException: Unable to connect to the 
 2024-09-12T15:56:33.125352208Z Thread-4 INFO Loading mask data from '/seed/specs_secrets_mask.yaml
 `)
 
+var testLogs2 = strings.TrimSpace(`
+2024-11-12 20:52:07,403 [main]	[1;31mERROR[0;39m	i.a.d.c.DatabaseAvailabilityCheck(lambda$isDatabaseConnected$1):78 - Failed to verify database connection.
+org.jooq.exception.DataAccessException: Error getting connection from data source HikariDataSource (HikariPool-1)
+	at org.jooq_3.19.7.POSTGRES.debug(Unknown Source)
+	at org.jooq.impl.DataSourceConnectionProvider.acquire(DataSourceConnectionProvider.java:90)
+Caused by: java.sql.SQLTransientConnectionException: HikariPool-1 - Connection is not available, request timed out after 30110ms (total=0, active=0, idle=0, waiting=0)
+	at com.zaxxer.hikari.pool.HikariPool.createTimeoutException(HikariPool.java:686)
+	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:179)
+	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:144)
+	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:99)
+	at org.jooq.impl.DataSourceConnectionProvider.acquire(DataSourceConnectionProvider.java:87)
+	... 22 common frames omitted
+Caused by: org.postgresql.util.PSQLException: The connection attempt failed.
+	at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:364)
+	at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:54)
+Caused by: java.net.UnknownHostException: airbyte-db-svc
+	at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:567)
+	at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:268)
+	... 14 common frames omitted
+`)
+
 func TestJavaLogScanner(t *testing.T) {
 	s := newLogScanner(strings.NewReader(testLogs))
 
@@ -46,15 +67,4 @@ func TestJavaLogScanner(t *testing.T) {
 	expectLogLine("ERROR", "Caused by: io.airbyte.db.check.DatabaseCheckException: Unable to connect to the database.")
 	expectLogLine("INFO", "i.m.r.Micronaut(lambda$start$0):118 - Embedded Application shutting down")
 	expectLogLine("INFO", "2024-09-12T15:56:33.125352208Z Thread-4 INFO Loading mask data from '/seed/specs_secrets_mask.yaml")
-}
-
-func TestLastErrorLog(t *testing.T) {
-	l, err := getLastLogError(strings.NewReader(testLogs))
-	if err != nil {
-		t.Errorf("unexpected error %s", err)
-	}
-	expect := "Caused by: io.airbyte.db.check.DatabaseCheckException: Unable to connect to the database."
-	if l != expect {
-		t.Errorf("expected %q but got %q", expect, l)
-	}
 }

--- a/internal/cmd/local/localerr/localerr.go
+++ b/internal/cmd/local/localerr/localerr.go
@@ -80,4 +80,9 @@ IP addresses won't work. Ports won't work (e.g. example:8000). URLs won't work (
 
 By default, abctl will allow access from any hostname or IP, so you might not need the --host flag.`,
 	}
+
+	ErrBootloaderFailed = &LocalError{
+		msg: "bootloader failed",
+		help: "The bootloader failed to its initialization checks or migrations. Try running again with --verbose to see the full bootloader logs.",
+	}
 )


### PR DESCRIPTION
The log attachments in Sentry only contain the logs from the failed pod, not all pods. Very often it's the bootloader that's failed, but the bootloader logs don't say anything interesting – they just say the bootloader can't connect to the DB. So this PR would attach all logs from platform pods (only on airbyte chart failure) which hopefully gives us something more interesting to look at.

## Java log parse code gets removed

The code I wrote to try to parse java logs from the platform in `diagnoseAirbyteChartFailure` is mostly a failure. Most of the time it just returns 
```
unable to install airbyte chart: pod airbyte-abctl-airbyte-bootloader: unknown
```

There are a few variants in the telemetry, such as:
```
unable to install airbyte chart: pod airbyte-abctl-airbyte-bootloader: Caused by: io.airbyte.db.check.DatabaseCheckException: Unable to connect to the database.

unable to install airbyte chart: pod airbyte-abctl-airbyte-bootloader: Caused by: io.micronaut.context.exceptions.ConfigurationException: Could not resolve placeholder ${DATABASE_PASSWORD}

unable to install airbyte chart: pod airbyte-abctl-airbyte-bootloader: Caused by: org.postgresql.util.PSQLException: ERROR: type "refresh_type" already exists

unable to install airbyte chart: pod airbyte-abctl-airbyte-bootloader: Caused by: org.postgresql.util.PSQLException: ERROR: must be owner of table airbyte_configs
```

These don't seem very clear for the user. The code to parse java logs lines is clunky and broken and not clearly valuable, so I've removed it in this PR. When the bootloader is the only failed pod, I return an error with a help message that says to run again with `--verbose` to see the full bootloader logs.