### PR TITLE
fix: panic when image pull fails

### DIFF
--- a/internal/cmd/local/k8s/load_images.go
+++ b/internal/cmd/local/k8s/load_images.go
@@ -38,9 +38,10 @@ func loadImages(ctx context.Context, dockerClient docker.Client, nodes []nodesli
 				pterm.Debug.Printfln("error pulling image %s", err)
 				// image pull errors are intentionally dropped because we're in a goroutine,
 				// and because we don't want to interrupt other image pulls.
+			} else {
+				defer r.Close()
+				io.Copy(io.Discard, r)
 			}
-			defer r.Close()
-			io.Copy(io.Discard, r)
 		}(img)
 	}
 	wg.Wait()


### PR DESCRIPTION
- fix https://github.com/airbytehq/airbyte-internal-issues/issues/11080
- if the image pull fails with an error, don't attempt to use the response