### PR TITLE
chore: pull logs from anything airbyte-*

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -25,7 +25,7 @@ type Cmd struct {
 	Verbose verbose     `short:"v" help:"Enable verbose output."`
 }
 
-func (c *Cmd) BeforeApply(ctx context.Context, kCtx *kong.Context) error {
+func (c *Cmd) BeforeApply(_ context.Context, kCtx *kong.Context) error {
 	kCtx.BindTo(k8s.DefaultProvider, (*k8s.Provider)(nil))
 	return nil
 }

--- a/internal/cmd/local/local/install.go
+++ b/internal/cmd/local/local/install.go
@@ -324,7 +324,7 @@ func (c *Command) diagnoseAirbyteChartFailure(ctx context.Context, chartErr erro
 	if errors.Is(ctx.Err(), context.Canceled) {
 		return chartErr
 	}
-	
+
 	podList, err := c.k8s.PodList(ctx, common.AirbyteNamespace)
 	if err != nil {
 		return chartErr
@@ -344,7 +344,9 @@ func (c *Command) diagnoseAirbyteChartFailure(ctx context.Context, chartErr erro
 
 	for _, pod := range podList.Items {
 		// skip pods that aren't part of the platform release (e.g. job pods)
-		if !strings.HasPrefix(pod.Name, common.AirbyteChartRelease) {
+		// note: the db (airbyte-db-0) and minio (airbyte-minio-0) pods are not release-name aware
+		// so we need to check for pod names that start with "airbyte"
+		if !strings.HasPrefix(pod.Name, "airbyte") {
 			continue
 		}
 		pterm.Debug.Printfln("looking at %s\n  %s(%s)", pod.Name, pod.Status.Phase, pod.Status.Reason)

--- a/main.go
+++ b/main.go
@@ -115,7 +115,6 @@ func checkForNewerAbctlVersion(ctx context.Context) func() {
 		ver := <-c
 		if ver != "" {
 			pterm.Info.Printfln("A new release of abctl is available: %s -> %s\nUpdating to the latest version is highly recommended", build.Version, ver)
-
 		}
 	}
 }


### PR DESCRIPTION
- pull logs from anything that starts with `airbyte*`
    - previously we only pulled logs from `airbyte-abctl-*` pods which didn't pull the `airbyte-db-0` and `airbyte-minio-0` logs
    - this makes debugging certain failure scenarios more difficult than it needs to be