### PR TITLE
feat: json logs from the bootloader

### DIFF
--- a/internal/cmd/local/helm/airbyte_values.go
+++ b/internal/cmd/local/helm/airbyte_values.go
@@ -25,6 +25,7 @@ func BuildAirbyteValues(ctx context.Context, opts ValuesOpts) (string, error) {
 		"global.auth.enabled=true",
 		"global.jobs.resources.limits.cpu=3",
 		"global.jobs.resources.limits.memory=4Gi",
+		"airbyte-bootloader.env_vars.PLATFORM_LOG_FORMAT=json",
 	}
 
 	span.SetAttributes(

--- a/internal/cmd/local/local/install.go
+++ b/internal/cmd/local/local/install.go
@@ -442,10 +442,10 @@ func (c *Command) streamPodLogs(ctx context.Context, namespace, podName, prefix 
 
 	s := newLogScanner(r)
 	for s.Scan() {
-		if s.line.level == "ERROR" {
-			pterm.Error.Printfln("%s: %s", prefix, s.line.msg)
+		if s.line.Level == "ERROR" {
+			pterm.Error.Printfln("%s: %s", prefix, s.line.Message)
 		} else {
-			pterm.Debug.Printfln("%s: %s", prefix, s.line.msg)
+			pterm.Debug.Printfln("%s: %s", prefix, s.line.Message)
 		}
 	}
 

--- a/internal/cmd/local/local/log_utils_test.go
+++ b/internal/cmd/local/local/log_utils_test.go
@@ -6,20 +6,8 @@ import (
 )
 
 var testLogs = strings.TrimSpace(`
-2024-09-12 15:56:25 [32mINFO[m i.a.d.c.DatabaseAvailabilityCheck(check):49 - Database is not ready yet. Please wait a moment, it might still be initializing...
-2024-09-12 15:56:30 [33mWARN[m i.m.s.r.u.Loggers$Slf4JLogger(warn):299 - [54bd6014, L:/127.0.0.1:52991 - R:localhost/127.0.0.1:8125] An exception has been observed post termination, use DEBUG level to see the full stack: java.net.PortUnreachableException: recvAddress(..) failed: Connection refused
-2024-09-12 15:56:31 [1;31mERROR[m i.a.b.Application(main):25 - Unable to bootstrap Airbyte environment.
-io.airbyte.db.init.DatabaseInitializationException: Database availability check failed.
-	at io.airbyte.db.init.DatabaseInitializer.initialize(DatabaseInitializer.java:54) ~[io.airbyte.airbyte-db-db-lib-0.64.3.jar:?]
-	at io.airbyte.bootloader.Bootloader.initializeDatabases(Bootloader.java:229) ~[io.airbyte-airbyte-bootloader-0.64.3.jar:?]
-	at io.airbyte.bootloader.Bootloader.load(Bootloader.java:104) ~[io.airbyte-airbyte-bootloader-0.64.3.jar:?]
-	at io.airbyte.bootloader.Application.main(Application.java:22) [io.airbyte-airbyte-bootloader-0.64.3.jar:?]
-Caused by: io.airbyte.db.check.DatabaseCheckException: Unable to connect to the database.
-	at io.airbyte.db.check.DatabaseAvailabilityCheck.check(DatabaseAvailabilityCheck.java:40) ~[io.airbyte.airbyte-db-db-lib-0.64.3.jar:?]
-	at io.airbyte.db.init.DatabaseInitializer.initialize(DatabaseInitializer.java:45) ~[io.airbyte.airbyte-db-db-lib-0.64.3.jar:?]
-	... 3 more
-2024-09-12 15:56:31 [32mINFO[m i.m.r.Micronaut(lambda$start$0):118 - Embedded Application shutting down
-2024-09-12T15:56:33.125352208Z Thread-4 INFO Loading mask data from '/seed/specs_secrets_mask.yaml
+nonjsonline
+{"timestamp":1734723317023,"message":"Waiting for database to become available...","level":"WARN","logSource":"platform","caller":{"className":"io.airbyte.db.check.DatabaseAvailabilityCheck","methodName":"check","lineNumber":38,"threadName":"main"},"throwable":null}
 `)
 
 func TestJavaLogScanner(t *testing.T) {
@@ -28,22 +16,17 @@ func TestJavaLogScanner(t *testing.T) {
 	expectLogLine := func(level, msg string) {
 		s.Scan()
 
-		if s.line.level != level {
-			t.Errorf("expected level %q but got %q", level, s.line.level)
+		if s.line.Level != level {
+			t.Errorf("expected level %q but got %q", level, s.line.Level)
 		}
-		if s.line.msg != msg {
-			t.Errorf("expected msg %q but got %q", msg, s.line.msg)
+		if s.line.Message != msg {
+			t.Errorf("expected msg %q but got %q", msg, s.line.Message)
 		}
 		if s.Err() != nil {
 			t.Errorf("unexpected error %v", s.Err())
 		}
 	}
 
-	expectLogLine("INFO", "i.a.d.c.DatabaseAvailabilityCheck(check):49 - Database is not ready yet. Please wait a moment, it might still be initializing...")
-	expectLogLine("WARN", "i.m.s.r.u.Loggers$Slf4JLogger(warn):299 - [54bd6014, L:/127.0.0.1:52991 - R:localhost/127.0.0.1:8125] An exception has been observed post termination, use DEBUG level to see the full stack: java.net.PortUnreachableException: recvAddress(..) failed: Connection refused")
-	expectLogLine("ERROR", "i.a.b.Application(main):25 - Unable to bootstrap Airbyte environment.")
-	expectLogLine("ERROR", "io.airbyte.db.init.DatabaseInitializationException: Database availability check failed.")
-	expectLogLine("ERROR", "Caused by: io.airbyte.db.check.DatabaseCheckException: Unable to connect to the database.")
-	expectLogLine("INFO", "i.m.r.Micronaut(lambda$start$0):118 - Embedded Application shutting down")
-	expectLogLine("INFO", "2024-09-12T15:56:33.125352208Z Thread-4 INFO Loading mask data from '/seed/specs_secrets_mask.yaml")
+	expectLogLine("", "nonjsonline")
+	expectLogLine("WARN", "Waiting for database to become available...")
 }

--- a/internal/cmd/local/local/testdata/expected-default.values.yaml
+++ b/internal/cmd/local/local/testdata/expected-default.values.yaml
@@ -1,3 +1,6 @@
+airbyte-bootloader:
+    env_vars:
+        PLATFORM_LOG_FORMAT: json
 global:
     auth:
         enabled: "true"


### PR DESCRIPTION
This configures the bootloader to emit JSON formatted logs, and changes the log scanner in abctl to read JSON. This improves abctl's ability to recognize error logs from the bootloader and show them to the user.

<img width="707" alt="image" src="https://github.com/user-attachments/assets/713e546c-5117-4ce5-99d9-92027d577947" />

The existing log scanner wasn't working anymore, and barely worked to begin with, so I removed it rather than keep it around to try to parse non-json logs.