### PR TITLE
feat: add optional flag to install airbyte with auth disabled

### DIFF
--- a/internal/cmd/local/helm/airbyte_values.go
+++ b/internal/cmd/local/helm/airbyte_values.go
@@ -15,6 +15,7 @@ type ValuesOpts struct {
 	InsecureCookies bool
 	TelemetryUser   string
 	ImagePullSecret string
+	DisableAuth     bool
 }
 
 func BuildAirbyteValues(ctx context.Context, opts ValuesOpts) (string, error) {
@@ -22,7 +23,6 @@ func BuildAirbyteValues(ctx context.Context, opts ValuesOpts) (string, error) {
 
 	vals := []string{
 		"global.env_vars.AIRBYTE_INSTALLATION_ID=" + opts.TelemetryUser,
-		"global.auth.enabled=true",
 		"global.jobs.resources.limits.cpu=3",
 		"global.jobs.resources.limits.memory=4Gi",
 	}
@@ -32,6 +32,10 @@ func BuildAirbyteValues(ctx context.Context, opts ValuesOpts) (string, error) {
 		attribute.Bool("insecure-cookies", opts.InsecureCookies),
 		attribute.Bool("image-pull-secret", opts.ImagePullSecret != ""),
 	)
+
+	if !opts.DisableAuth {
+		vals = append(vals, "global.auth.enabled=true")
+	}
 
 	if opts.LowResourceMode {
 		vals = append(vals,

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -18,7 +18,7 @@ import (
 type InstallCmd struct {
 	Chart           string   `help:"Path to chart." xor:"chartver"`
 	ChartVersion    string   `help:"Version to install." xor:"chartver"`
-	DisableAuth     bool     `help:"Disable Auth."`
+	DisableAuth     bool     `help:"Disable auth."`
 	DockerEmail     string   `group:"docker" help:"Docker email." env:"ABCTL_LOCAL_INSTALL_DOCKER_EMAIL"`
 	DockerPassword  string   `group:"docker" help:"Docker password." env:"ABCTL_LOCAL_INSTALL_DOCKER_PASSWORD"`
 	DockerServer    string   `group:"docker" default:"https://index.docker.io/v1/" help:"Docker server." env:"ABCTL_LOCAL_INSTALL_DOCKER_SERVER"`

--- a/internal/cmd/local/local_install.go
+++ b/internal/cmd/local/local_install.go
@@ -18,6 +18,7 @@ import (
 type InstallCmd struct {
 	Chart           string   `help:"Path to chart." xor:"chartver"`
 	ChartVersion    string   `help:"Version to install." xor:"chartver"`
+	DisableAuth     bool     `help:"Disable Auth."`
 	DockerEmail     string   `group:"docker" help:"Docker email." env:"ABCTL_LOCAL_INSTALL_DOCKER_EMAIL"`
 	DockerPassword  string   `group:"docker" help:"Docker password." env:"ABCTL_LOCAL_INSTALL_DOCKER_PASSWORD"`
 	DockerServer    string   `group:"docker" default:"https://index.docker.io/v1/" help:"Docker server." env:"ABCTL_LOCAL_INSTALL_DOCKER_SERVER"`
@@ -68,6 +69,7 @@ func (i *InstallCmd) InstallOpts(ctx context.Context, user string) (*local.Insta
 		ValuesFile:      i.Values,
 		InsecureCookies: i.InsecureCookies,
 		LowResourceMode: i.LowResourceMode,
+		DisableAuth:     i.DisableAuth,
 	}
 
 	if opts.DockerAuth() {
@@ -166,9 +168,9 @@ func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient t
 			return fmt.Errorf("unable to initialize local command: %w", err)
 		}
 
-		spinner.UpdateText("Pulling images")		
+		spinner.UpdateText("Pulling images")
 		lc.PrepImages(ctx, cluster, opts)
-		
+
 		if err := lc.Install(ctx, opts); err != nil {
 			spinner.Fail("Unable to install Airbyte locally")
 			return err


### PR DESCRIPTION
My team uses abctl to run airbyte locally on our development machines as part of our development flow.

for simplicity we disable auth during development. today we do this by passing a values file to abctl however it would be much nicer to have this option as a command line argument just like `--low-resource-mode`.

looked it up in the source code and saw its pretty easy to implement so i went ahead and implemented it.