### PR TITLE
chore: move ParseVolumeMounts to the k8s package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pterm/pterm v0.12.80
+	github.com/stretchr/testify v1.10.0
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/otel v1.32.0
 	go.opentelemetry.io/otel/sdk v1.32.0
@@ -131,6 +132,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.61.0 // indirect

--- a/internal/cmd/local/install.go
+++ b/internal/cmd/local/install.go
@@ -3,7 +3,6 @@ package local
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/airbytehq/abctl/internal/common"
 	"github.com/airbytehq/abctl/internal/helm"
@@ -37,7 +36,7 @@ func (i *InstallCmd) InstallOpts(ctx context.Context, user string) (*service.Ins
 	ctx, span := trace.NewSpan(ctx, "InstallCmd.InstallOpts")
 	defer span.End()
 
-	extraVolumeMounts, err := parseVolumeMounts(i.Volume)
+	extraVolumeMounts, err := k8s.ParseVolumeMounts(i.Volume)
 	if err != nil {
 		return nil, err
 	}
@@ -210,25 +209,4 @@ func (i *InstallCmd) Run(ctx context.Context, provider k8s.Provider, telClient t
 		)
 		return nil
 	})
-}
-
-func parseVolumeMounts(specs []string) ([]k8s.ExtraVolumeMount, error) {
-	if len(specs) == 0 {
-		return nil, nil
-	}
-
-	mounts := make([]k8s.ExtraVolumeMount, len(specs))
-
-	for i, spec := range specs {
-		parts := strings.Split(spec, ":")
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("volume %s is not a valid volume spec, must be <HOST_PATH>:<GUEST_PATH>", spec)
-		}
-		mounts[i] = k8s.ExtraVolumeMount{
-			HostPath:      parts[0],
-			ContainerPath: parts[1],
-		}
-	}
-
-	return mounts, nil
 }

--- a/internal/k8s/volumes.go
+++ b/internal/k8s/volumes.go
@@ -1,0 +1,34 @@
+package k8s
+
+import (
+	"fmt"
+	"strings"
+)
+
+// errInvalidVolumeMountSpec returns an error for an invalid volume mount spec.
+func errInvalidVolumeMountSpec(spec string) error {
+	return fmt.Errorf("volume %s is not a valid volume spec, must be <HOST_PATH>:<GUEST_PATH>", spec)
+}
+
+// ParseVolumeMounts parses a slice of volume mount specs in the format <HOST_PATH>:<GUEST_PATH>
+// and returns a slice of ExtraVolumeMount. Returns an error if any spec is invalid.
+func ParseVolumeMounts(specs []string) ([]ExtraVolumeMount, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+
+	mounts := make([]ExtraVolumeMount, len(specs))
+
+	for i, spec := range specs {
+		parts := strings.Split(spec, ":")
+		if len(parts) != 2 {
+			return nil, errInvalidVolumeMountSpec(spec)
+		}
+		mounts[i] = ExtraVolumeMount{
+			HostPath:      parts[0],
+			ContainerPath: parts[1],
+		}
+	}
+
+	return mounts, nil
+}

--- a/internal/k8s/volumes_test.go
+++ b/internal/k8s/volumes_test.go
@@ -1,0 +1,55 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseVolumeMounts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		input        []string
+		expectMounts []ExtraVolumeMount
+		expectErr    error
+	}{
+		{
+			name: "empty input",
+		},
+		{
+			name:         "single valid mount",
+			input:        []string{"/host:/container"},
+			expectMounts: []ExtraVolumeMount{{HostPath: "/host", ContainerPath: "/container"}},
+		},
+		{
+			name:         "multiple valid mounts",
+			input:        []string{"/a:/b", "/c:/d"},
+			expectMounts: []ExtraVolumeMount{{HostPath: "/a", ContainerPath: "/b"}, {HostPath: "/c", ContainerPath: "/d"}},
+		},
+		{
+			name:      "invalid spec (missing colon)",
+			input:     []string{"/hostcontainer"},
+			expectErr: errInvalidVolumeMountSpec("/hostcontainer"),
+		},
+		{
+			name:      "invalid spec (too many colons)",
+			input:     []string{"/a:/b:/c"},
+			expectErr: errInvalidVolumeMountSpec("/a:/b:/c"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mounts, err := ParseVolumeMounts(tt.input)
+			assert.Equal(t, tt.expectMounts, mounts, "mounts should match")
+			if tt.expectErr != nil {
+				assert.EqualError(t, err, tt.expectErr.Error(), "errors should match")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This function is more k8s-related since it returns a k8s.ExtraVolumeMount slice that is only used by the k8s package. Moving it also helps reduce the footprint of the local install package.

My intention is to later break up "install options" and "infra options". This will mean that we can do more powerful querying against Helm when computing Helm values, etc. Obviously this needs to happen after infra has been provisioned. Separating the options helps us to do that. Meaning we can move the computing of install options further down the install code path.