### PR TITLE
fix: secure cookie setting

### DIFF
--- a/internal/helm/airbyte_values.go
+++ b/internal/helm/airbyte_values.go
@@ -77,7 +77,8 @@ func BuildAirbyteValues(ctx context.Context, opts ValuesOpts) (string, error) {
 	}
 
 	if opts.InsecureCookies {
-		vals = append(vals, "global.auth.cookieSecureSetting=false")
+		// Boolean is a string value in the v1 Helm chart.
+		vals = append(vals, `global.auth.cookieSecureSetting="false"`)
 	}
 
 	fileVals, err := maps.FromYAMLFile(opts.ValuesFile)

--- a/internal/helm/airbyte_values_test.go
+++ b/internal/helm/airbyte_values_test.go
@@ -1,0 +1,222 @@
+package helm
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestBuildAirbyteValues(t *testing.T) {
+	testdataDir := filepath.Join("..", "cmd", "local", "testdata")
+	cases := []struct {
+		name    string
+		opts    ValuesOpts
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "default options",
+			opts: ValuesOpts{TelemetryUser: "test-user"},
+			want: `airbyte-bootloader:
+    env_vars:
+        PLATFORM_LOG_FORMAT: json
+global:
+    auth:
+        enabled: true
+    env_vars:
+        AIRBYTE_INSTALLATION_ID: test-user
+    jobs:
+        resources:
+            limits:
+                cpu: "3"
+                memory: 4Gi
+`,
+		},
+		{
+			name: "local storage enabled",
+			opts: ValuesOpts{TelemetryUser: "test-user", LocalStorage: true},
+			want: `airbyte-bootloader:
+    env_vars:
+        PLATFORM_LOG_FORMAT: json
+global:
+    auth:
+        enabled: true
+    env_vars:
+        AIRBYTE_INSTALLATION_ID: test-user
+    jobs:
+        resources:
+            limits:
+                cpu: "3"
+                memory: 4Gi
+    storage:
+        type: local
+`,
+		},
+		{
+			name: "psql 1.7 enabled",
+			opts: ValuesOpts{TelemetryUser: "test-user", EnablePsql17: true},
+			want: `airbyte-bootloader:
+    env_vars:
+        PLATFORM_LOG_FORMAT: json
+global:
+    auth:
+        enabled: true
+    env_vars:
+        AIRBYTE_INSTALLATION_ID: test-user
+    jobs:
+        resources:
+            limits:
+                cpu: "3"
+                memory: 4Gi
+postgresql:
+    image:
+        tag: 1.7.0-17
+`,
+		},
+		{
+			name: "custom values file merges and overrides",
+			opts: ValuesOpts{
+				TelemetryUser: "test-user",
+				ValuesFile:    filepath.Join(testdataDir, "expected-default.values.yaml"),
+			},
+			want: `airbyte-bootloader:
+    env_vars:
+        PLATFORM_LOG_FORMAT: json
+global:
+    auth:
+        enabled: true
+    env_vars:
+        AIRBYTE_INSTALLATION_ID: test-user
+    jobs:
+        resources:
+            limits:
+                cpu: "3"
+                memory: 4Gi
+    storage:
+        type: local
+postgresql:
+    image:
+        tag: 1.7.0-17
+`,
+		},
+		{
+			name: "invalid values file returns error",
+			opts: ValuesOpts{
+				TelemetryUser: "test-user",
+				ValuesFile:    filepath.Join(testdataDir, "invalid.values.yaml"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "auth disabled",
+			opts: ValuesOpts{TelemetryUser: "test-user", DisableAuth: true},
+			want: `airbyte-bootloader:
+    env_vars:
+        PLATFORM_LOG_FORMAT: json
+global:
+    env_vars:
+        AIRBYTE_INSTALLATION_ID: test-user
+    jobs:
+        resources:
+            limits:
+                cpu: "3"
+                memory: 4Gi
+`,
+		},
+		{
+			name: "low resource mode",
+			opts: ValuesOpts{TelemetryUser: "test-user", LowResourceMode: true},
+			want: `airbyte-bootloader:
+    env_vars:
+        PLATFORM_LOG_FORMAT: json
+connector-builder-server:
+    enabled: false
+global:
+    auth:
+        enabled: true
+    env_vars:
+        AIRBYTE_INSTALLATION_ID: test-user
+    jobs:
+        resources:
+            limits:
+                cpu: "3"
+                memory: 4Gi
+            requests:
+                cpu: "0"
+                memory: "0"
+server:
+    env_vars:
+        JOB_RESOURCE_VARIANT_OVERRIDE: lowresource
+workload-launcher:
+    env_vars:
+        CHECK_JOB_MAIN_CONTAINER_CPU_REQUEST: "0"
+        CHECK_JOB_MAIN_CONTAINER_MEMORY_REQUEST: "0"
+        DISCOVER_JOB_MAIN_CONTAINER_CPU_REQUEST: "0"
+        DISCOVER_JOB_MAIN_CONTAINER_MEMORY_REQUEST: "0"
+        SIDECAR_MAIN_CONTAINER_CPU_REQUEST: "0"
+        SIDECAR_MAIN_CONTAINER_MEMORY_REQUEST: "0"
+        SPEC_JOB_MAIN_CONTAINER_CPU_REQUEST: "0"
+        SPEC_JOB_MAIN_CONTAINER_MEMORY_REQUEST: "0"
+`,
+		},
+		{
+			name: "insecure cookies disabled",
+			opts: ValuesOpts{TelemetryUser: "test-user", InsecureCookies: true},
+			want: `airbyte-bootloader:
+    env_vars:
+        PLATFORM_LOG_FORMAT: json
+global:
+    auth:
+        cookieSecureSetting: '"false"'
+        enabled: true
+    env_vars:
+        AIRBYTE_INSTALLATION_ID: test-user
+    jobs:
+        resources:
+            limits:
+                cpu: "3"
+                memory: 4Gi
+`,
+		},
+		{
+			name: "image pull secret set",
+			opts: ValuesOpts{TelemetryUser: "test-user", ImagePullSecret: "mysecret"},
+			want: `airbyte-bootloader:
+    env_vars:
+        PLATFORM_LOG_FORMAT: json
+global:
+    auth:
+        enabled: true
+    env_vars:
+        AIRBYTE_INSTALLATION_ID: test-user
+    imagePullSecrets[0]:
+        name: mysecret
+    jobs:
+        resources:
+            limits:
+                cpu: "3"
+                memory: 4Gi
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			got, err := BuildAirbyteValues(ctx, tc.opts)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			var wantMap, gotMap map[string]any
+			require.NoError(t, yaml.Unmarshal([]byte(tc.want), &wantMap), "unmarshal want yaml")
+			require.NoError(t, yaml.Unmarshal([]byte(got), &gotMap), "unmarshal got yaml")
+			require.Equal(t, wantMap, gotMap)
+		})
+	}
+}


### PR DESCRIPTION
The v1 Helm chart expects the secure cookie value as a string, not a boolean. A previous change in Abctl converted "true"/"false" to booleans, which broke this setting. This commit ensures the override value is treated as a string and adds tests to verify the behavior.

When using default values (no `--insecure-cookies` flag):
<img width="1451" height="119" alt="Screenshot 2025-07-11 at 9 46 45 AM" src="https://github.com/user-attachments/assets/c4f7e42f-1dff-4fe4-8012-15072bce203c" />

When setting the  `--insecure-cookies` flag:
<img width="1511" height="137" alt="Screenshot 2025-07-11 at 9 45 27 AM" src="https://github.com/user-attachments/assets/238cd6a1-e828-4968-9f1c-3a8d350c2a03" />
