### PR TITLE
feat: rework the comand structure to be VERB NOUN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ ABCTL_VERSION?=dev
 build:
 	CGO_ENABLED=0 go build -trimpath -o build/ -ldflags "-w -X github.com/airbytehq/abctl/internal/build.Version=$(ABCTL_VERSION)" .
 
+.PHONY: build-new
+build-new:
+	CGO_ENABLED=0 go build -tags newcli -trimpath -o build/abctl-new -ldflags "-w -X github.com/airbytehq/abctl/internal/build.Version=$(ABCTL_VERSION)" main_new.go
+
 .PHONY: clean
 clean:
 	rm -rf build/

--- a/go.mod
+++ b/go.mod
@@ -183,5 +183,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.3 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-tool go.uber.org/mock/mockgen

--- a/internal/cmd/cmd_new.go
+++ b/internal/cmd/cmd_new.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/airbytehq/abctl/internal/cmd/verbs"
+	"github.com/airbytehq/abctl/internal/k8s"
+	"github.com/airbytehq/abctl/internal/service"
+	"github.com/alecthomas/kong"
+	"github.com/pterm/pterm"
+)
+
+type verboseNew bool
+
+func (v verboseNew) BeforeApply() error {
+	pterm.EnableDebugMessages()
+	return nil
+}
+
+type CmdNew struct {
+	Get    verbs.GetCmd    `cmd:"" help:"Get resource information."`
+	List   verbs.ListCmd   `cmd:"" help:"List resources."`
+	Create verbs.CreateCmd `cmd:"" help:"Create resources."`
+	Edit   verbs.EditCmd   `cmd:"" help:"Edit resources."`
+	Delete verbs.DeleteCmd `cmd:"" help:"Delete resources."`
+	Logs   verbs.LogsCmd   `cmd:"" help:"View resource logs."`
+
+	Verbose verboseNew `short:"v" help:"Enable verbose output."`
+}
+
+func (c *CmdNew) BeforeApply(_ context.Context, kCtx *kong.Context) error {
+	kCtx.BindTo(k8s.DefaultProvider, (*k8s.Provider)(nil))
+	kCtx.BindTo(service.DefaultManagerClientFactory, (*service.ManagerClientFactory)(nil))
+	return nil
+}

--- a/internal/cmd/verbs/create.go
+++ b/internal/cmd/verbs/create.go
@@ -1,0 +1,19 @@
+package verbs
+
+import (
+	"github.com/airbytehq/abctl/internal/nouns/airbyte"
+	"github.com/airbytehq/abctl/internal/nouns/dataplane"
+	"github.com/airbytehq/abctl/internal/nouns/region"
+	"github.com/airbytehq/abctl/internal/nouns/workspace"
+)
+
+type CreateCmd struct {
+	Airbyte    airbyte.Creator   `cmd:"" help:"Create local Airbyte installation."`
+	Airbytes   airbyte.Creator   `cmd:"airbytes" aliases:"airbytes" help:"Create local Airbyte installation (plural)."`
+	Dataplane  dataplane.Creator `cmd:"" help:"Create dataplane."`
+	Dataplanes dataplane.Creator `cmd:"dataplanes" aliases:"dataplanes" help:"Create dataplane (plural)."`
+	Region     region.Creator    `cmd:"" help:"Create region."`
+	Regions    region.Creator    `cmd:"regions" aliases:"regions" help:"Create region (plural)."`
+	Workspace  workspace.Creator `cmd:"" help:"Create workspace."`
+	Workspaces workspace.Creator `cmd:"workspaces" aliases:"workspaces" help:"Create workspace (plural)."`
+}

--- a/internal/cmd/verbs/delete.go
+++ b/internal/cmd/verbs/delete.go
@@ -1,0 +1,19 @@
+package verbs
+
+import (
+	"github.com/airbytehq/abctl/internal/nouns/airbyte"
+	"github.com/airbytehq/abctl/internal/nouns/dataplane"
+	"github.com/airbytehq/abctl/internal/nouns/region"
+	"github.com/airbytehq/abctl/internal/nouns/workspace"
+)
+
+type DeleteCmd struct {
+	Airbyte    airbyte.Deleter   `cmd:"" help:"Delete Airbyte installation."`
+	Airbytes   airbyte.Deleter   `cmd:"airbytes" aliases:"airbytes" help:"Delete Airbyte installation (plural)."`
+	Dataplane  dataplane.Deleter `cmd:"" help:"Delete dataplane."`
+	Dataplanes dataplane.Deleter `cmd:"dataplanes" aliases:"dataplanes" help:"Delete dataplane (plural)."`
+	Region     region.Deleter    `cmd:"" help:"Delete region."`
+	Regions    region.Deleter    `cmd:"regions" aliases:"regions" help:"Delete region (plural)."`
+	Workspace  workspace.Deleter `cmd:"" help:"Delete workspace."`
+	Workspaces workspace.Deleter `cmd:"workspaces" aliases:"workspaces" help:"Delete workspace (plural)."`
+}

--- a/internal/cmd/verbs/edit.go
+++ b/internal/cmd/verbs/edit.go
@@ -1,0 +1,19 @@
+package verbs
+
+import (
+	"github.com/airbytehq/abctl/internal/nouns/airbyte"
+	"github.com/airbytehq/abctl/internal/nouns/dataplane"
+	"github.com/airbytehq/abctl/internal/nouns/region"
+	"github.com/airbytehq/abctl/internal/nouns/workspace"
+)
+
+type EditCmd struct {
+	Airbyte    airbyte.Editor   `cmd:"" help:"Edit Airbyte configuration."`
+	Airbytes   airbyte.Editor   `cmd:"airbytes" aliases:"airbytes" help:"Edit Airbyte configuration (plural)."`
+	Dataplane  dataplane.Editor `cmd:"" help:"Edit dataplane configuration."`
+	Dataplanes dataplane.Editor `cmd:"dataplanes" aliases:"dataplanes" help:"Edit dataplane configuration (plural)."`
+	Region     region.Editor    `cmd:"" help:"Edit region configuration."`
+	Regions    region.Editor    `cmd:"regions" aliases:"regions" help:"Edit region configuration (plural)."`
+	Workspace  workspace.Editor `cmd:"" help:"Edit workspace configuration."`
+	Workspaces workspace.Editor `cmd:"workspaces" aliases:"workspaces" help:"Edit workspace configuration (plural)."`
+}

--- a/internal/cmd/verbs/get.go
+++ b/internal/cmd/verbs/get.go
@@ -1,0 +1,19 @@
+package verbs
+
+import (
+	"github.com/airbytehq/abctl/internal/nouns/airbyte"
+	"github.com/airbytehq/abctl/internal/nouns/dataplane"
+	"github.com/airbytehq/abctl/internal/nouns/region"
+	"github.com/airbytehq/abctl/internal/nouns/workspace"
+)
+
+type GetCmd struct {
+	Airbyte   airbyte.Getter   `cmd:"" help:"Get Airbyte information."`
+	Airbytes  airbyte.Getter   `cmd:"airbytes" aliases:"airbytes" help:"Get Airbyte information (plural)."`
+	Dataplane  dataplane.Getter `cmd:"" help:"Get dataplane information."`
+	Dataplanes dataplane.Getter `cmd:"dataplanes" aliases:"dataplanes" help:"Get dataplane information (plural)."`
+	Region     region.Getter    `cmd:"" help:"Get region information."`
+	Regions    region.Getter    `cmd:"regions" aliases:"regions" help:"Get region information (plural)."`
+	Workspace  workspace.Getter `cmd:"" help:"Get workspace information."`
+	Workspaces workspace.Getter `cmd:"workspaces" aliases:"workspaces" help:"Get workspace information (plural)."`
+}

--- a/internal/cmd/verbs/list.go
+++ b/internal/cmd/verbs/list.go
@@ -1,0 +1,19 @@
+package verbs
+
+import (
+	"github.com/airbytehq/abctl/internal/nouns/airbyte"
+	"github.com/airbytehq/abctl/internal/nouns/dataplane"
+	"github.com/airbytehq/abctl/internal/nouns/region"
+	"github.com/airbytehq/abctl/internal/nouns/workspace"
+)
+
+type ListCmd struct {
+	Airbyte    airbyte.Lister   `cmd:"" help:"List Airbyte deployments."`
+	Airbytes   airbyte.Lister   `cmd:"airbytes" aliases:"airbytes" help:"List Airbyte deployments (plural)."`
+	Dataplane  dataplane.Lister `cmd:"" help:"List dataplanes."`
+	Dataplanes dataplane.Lister `cmd:"dataplanes" aliases:"dataplanes" help:"List dataplanes (plural)."`
+	Region     region.Lister    `cmd:"" help:"List regions."`
+	Regions    region.Lister    `cmd:"regions" aliases:"regions" help:"List regions (plural)."`
+	Workspace  workspace.Lister `cmd:"" help:"List workspaces."`
+	Workspaces workspace.Lister `cmd:"workspaces" aliases:"workspaces" help:"List workspaces (plural)."`
+}

--- a/internal/cmd/verbs/logs.go
+++ b/internal/cmd/verbs/logs.go
@@ -1,0 +1,19 @@
+package verbs
+
+import (
+	"github.com/airbytehq/abctl/internal/nouns/airbyte"
+	"github.com/airbytehq/abctl/internal/nouns/dataplane"
+	"github.com/airbytehq/abctl/internal/nouns/region"
+	"github.com/airbytehq/abctl/internal/nouns/workspace"
+)
+
+type LogsCmd struct {
+	Airbyte    airbyte.Logger   `cmd:"" help:"View Airbyte logs."`
+	Airbytes   airbyte.Logger   `cmd:"airbytes" aliases:"airbytes" help:"View Airbyte logs (plural)."`
+	Dataplane  dataplane.Logger `cmd:"" help:"View dataplane logs."`
+	Dataplanes dataplane.Logger `cmd:"dataplanes" aliases:"dataplanes" help:"View dataplane logs (plural)."`
+	Region     region.Logger    `cmd:"" help:"View region logs."`
+	Regions    region.Logger    `cmd:"regions" aliases:"regions" help:"View region logs (plural)."`
+	Workspace  workspace.Logger `cmd:"" help:"View workspace logs."`
+	Workspaces workspace.Logger `cmd:"workspaces" aliases:"workspaces" help:"View workspace logs (plural)."`
+}

--- a/internal/nouns/airbyte/creator.go
+++ b/internal/nouns/airbyte/creator.go
@@ -1,0 +1,233 @@
+package airbyte
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/airbytehq/abctl/internal/common"
+	"github.com/airbytehq/abctl/internal/helm"
+	"github.com/airbytehq/abctl/internal/k8s"
+	"github.com/airbytehq/abctl/internal/service"
+	"github.com/airbytehq/abctl/internal/telemetry"
+	"github.com/airbytehq/abctl/internal/trace"
+	goHelm "github.com/mittwald/go-helm-client"
+	"github.com/pterm/pterm"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type Creator struct {
+	Chart           string   `help:"Path to chart." xor:"chartver"`
+	ChartVersion    string   `help:"Version to install." xor:"chartver"`
+	DisableAuth     bool     `help:"Disable auth."`
+	DockerEmail     string   `group:"docker" help:"Docker email." env:"ABCTL_LOCAL_INSTALL_DOCKER_EMAIL"`
+	DockerPassword  string   `group:"docker" help:"Docker password." env:"ABCTL_LOCAL_INSTALL_DOCKER_PASSWORD"`
+	DockerServer    string   `group:"docker" default:"https://index.docker.io/v1/" help:"Docker server." env:"ABCTL_LOCAL_INSTALL_DOCKER_SERVER"`
+	DockerUsername  string   `group:"docker" help:"Docker username." env:"ABCTL_LOCAL_INSTALL_DOCKER_USERNAME"`
+	Host            []string `help:"HTTP ingress host."`
+	InsecureCookies bool     `help:"Allow cookies to be served over HTTP."`
+	LowResourceMode bool     `help:"Run Airbyte in low resource mode."`
+	NoBrowser       bool     `help:"Disable launching a browser post install."`
+	Port            int      `default:"8000" help:"HTTP ingress port."`
+	Secret          []string `type:"existingfile" help:"An Airbyte helm chart secret file."`
+	Values          string   `type:"existingfile" help:"An Airbyte helm chart values file to configure helm."`
+	Volume          []string `help:"Additional volume mounts. Must be in the format <HOST_PATH>:<GUEST_PATH>."`
+}
+
+func (c *Creator) Run(ctx context.Context, provider k8s.Provider, newSvcMgrClients service.ManagerClientFactory, telClient telemetry.Client) error {
+	ctx, span := trace.NewSpan(ctx, "airbyte create")
+	defer span.End()
+
+	extraVolumeMounts, err := k8s.ParseVolumeMounts(c.Volume)
+	if err != nil {
+		return fmt.Errorf("failed to parse the extra volume mounts: %w", err)
+	}
+
+	spinner := &pterm.DefaultSpinner
+	spinner, _ = spinner.Start("Starting installation")
+	spinner.UpdateText("Checking for Docker installation")
+
+	_, err = dockerInstalled(ctx, telClient)
+	if err != nil {
+		pterm.Error.Println("Unable to determine if Docker is installed")
+		return fmt.Errorf("unable to determine docker installation status: %w", err)
+	}
+
+	return telClient.Wrap(ctx, telemetry.Install, func() error {
+		spinner.UpdateText(fmt.Sprintf("Checking for existing Kubernetes cluster '%s'", provider.ClusterName))
+
+		cluster, err := provider.Cluster(ctx)
+		if err != nil {
+			pterm.Error.Printfln("Unable to determine status of any existing '%s' cluster", provider.ClusterName)
+			return err
+		}
+
+		if cluster.Exists(ctx) {
+			pterm.Success.Printfln("Existing cluster '%s' found", provider.ClusterName)
+			spinner.UpdateText(fmt.Sprintf("Validating existing cluster '%s'", provider.ClusterName))
+			span.SetAttributes(attribute.Bool("cluster_exists", true))
+
+			if provider.Name == k8s.Kind {
+				providedPort := c.Port
+				c.Port, err = getPort(ctx, provider.ClusterName)
+				if err != nil {
+					return err
+				}
+				if providedPort != c.Port {
+					pterm.Warning.Printfln("The existing cluster was found to be using port %d, which differs from the provided port %d.\n"+
+						"The existing port will be used, as changing ports currently requires the existing installation to be uninstalled first.", c.Port, providedPort)
+				}
+			}
+
+			pterm.Success.Printfln("Cluster '%s' validation complete", provider.ClusterName)
+		} else {
+			pterm.Info.Println(fmt.Sprintf("No existing cluster found, cluster '%s' will be created", provider.ClusterName))
+			span.SetAttributes(attribute.Bool("cluster_exists", false))
+
+			spinner.UpdateText(fmt.Sprintf("Checking if port %d is available", c.Port))
+			if err := portAvailable(ctx, c.Port); err != nil {
+				return err
+			}
+			pterm.Success.Printfln("Port %d appears to be available", c.Port)
+			spinner.UpdateText(fmt.Sprintf("Creating cluster '%s'", provider.ClusterName))
+
+			if err := cluster.Create(ctx, c.Port, extraVolumeMounts); err != nil {
+				pterm.Error.Printfln("Cluster '%s' could not be created", provider.ClusterName)
+				return err
+			}
+			pterm.Success.Printfln("Cluster '%s' created", provider.ClusterName)
+		}
+
+		k8sClient, helmClient, err := newSvcMgrClients(provider.Kubeconfig, provider.Context)
+		if err != nil {
+			return err
+		}
+
+		err = c.setDefaultChartFlags(helmClient)
+		if err != nil {
+			return fmt.Errorf("failed to set chart defaults: %w", err)
+		}
+
+		overrideImages := []string{}
+
+		opts, err := c.installOpts(ctx, telClient.User())
+		if err != nil {
+			return err
+		}
+
+		if opts.EnablePsql17 {
+			overrideImages = append(overrideImages, "airbyte/db:"+helm.Psql17AirbyteTag)
+		}
+
+		svcMgr, err := service.NewManager(provider,
+			service.WithK8sClient(k8sClient),
+			service.WithHelmClient(helmClient),
+			service.WithPortHTTP(c.Port),
+			service.WithTelemetryClient(telClient),
+			service.WithSpinner(spinner),
+			service.WithDockerClient(dockerAPI),
+		)
+		if err != nil {
+			pterm.Error.Printfln("Failed to initialize 'airbyte' command")
+			return fmt.Errorf("unable to initialize airbyte command: %w", err)
+		}
+
+		spinner.UpdateText("Pulling images")
+		svcMgr.PrepImages(ctx, cluster, opts, overrideImages...)
+
+		if err := svcMgr.Install(ctx, opts); err != nil {
+			spinner.Fail("Unable to install Airbyte locally")
+			return err
+		}
+
+		spinner.Success(
+			"Airbyte installation complete.\n" +
+				"  A password may be required to login. The password can by found by running\n" +
+				"  the command " + pterm.LightBlue("abctl get airbyte --credentials"),
+		)
+		return nil
+	})
+}
+
+func (c *Creator) installOpts(ctx context.Context, user string) (*service.InstallOpts, error) {
+	ctx, span := trace.NewSpan(ctx, "Creator.installOpts")
+	defer span.End()
+
+	span.SetAttributes(attribute.Bool("host", len(c.Host) > 0))
+
+	for _, host := range c.Host {
+		if err := validateHostFlag(host); err != nil {
+			return nil, err
+		}
+	}
+
+	supportMinio, err := service.SupportMinio()
+	if err != nil {
+		return nil, err
+	}
+
+	if supportMinio {
+		pterm.Warning.Println("Found MinIO physical volume. Consider migrating it to local storage (see project docs)")
+	}
+
+	enablePsql17, err := service.EnablePsql17()
+	if err != nil {
+		return nil, err
+	}
+
+	if !enablePsql17 {
+		pterm.Warning.Println("Psql 13 detected. Consider upgrading to 17")
+	}
+
+	opts := &service.InstallOpts{
+		HelmChartVersion: c.ChartVersion,
+		AirbyteChartLoc:  c.Chart,
+		Secrets:          c.Secret,
+		Hosts:            c.Host,
+		LocalStorage:     !supportMinio,
+		EnablePsql17:     enablePsql17,
+		DockerServer:     c.DockerServer,
+		DockerUser:       c.DockerUsername,
+		DockerPass:       c.DockerPassword,
+		DockerEmail:      c.DockerEmail,
+		NoBrowser:        c.NoBrowser,
+	}
+
+	valuesOpts := helm.ValuesOpts{
+		ValuesFile:      c.Values,
+		InsecureCookies: c.InsecureCookies,
+		LowResourceMode: c.LowResourceMode,
+		DisableAuth:     c.DisableAuth,
+		LocalStorage:    !supportMinio,
+		EnablePsql17:    enablePsql17,
+	}
+
+	if opts.DockerAuth() {
+		valuesOpts.ImagePullSecret = common.DockerAuthSecretName
+	}
+
+	if user != "" {
+		valuesOpts.TelemetryUser = user
+	}
+
+	valuesYAML, err := helm.BuildAirbyteValues(ctx, valuesOpts, c.ChartVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	opts.HelmValuesYaml = valuesYAML
+
+	return opts, nil
+}
+
+func (c *Creator) setDefaultChartFlags(helmClient goHelm.Client) error {
+	resolver := helm.NewChartResolver(helmClient)
+	resolvedChart, resolvedVersion, err := resolver.ResolveChartReference(c.Chart, c.ChartVersion)
+	if err != nil {
+		return fmt.Errorf("failed to resolve chart flags: %w", err)
+	}
+
+	c.Chart = resolvedChart
+	c.ChartVersion = resolvedVersion
+
+	return nil
+}

--- a/internal/nouns/airbyte/deleter.go
+++ b/internal/nouns/airbyte/deleter.go
@@ -1,0 +1,99 @@
+package airbyte
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/airbytehq/abctl/internal/k8s"
+	"github.com/airbytehq/abctl/internal/service"
+	"github.com/airbytehq/abctl/internal/telemetry"
+	"github.com/airbytehq/abctl/internal/trace"
+	"github.com/pterm/pterm"
+)
+
+type Deleter struct {
+	Force           bool `help:"Force deletion without confirmation."`
+	PersistVolumes  bool `help:"Preserve persisted data."`
+}
+
+func (d *Deleter) Run(ctx context.Context, provider k8s.Provider, newSvcMgrClients service.ManagerClientFactory, telClient telemetry.Client) error {
+	ctx, span := trace.NewSpan(ctx, "airbyte delete")
+	defer span.End()
+
+	cluster, err := provider.Cluster(ctx)
+	if err != nil {
+		pterm.Error.Printfln("Unable to determine cluster status")
+		return err
+	}
+
+	if !cluster.Exists(ctx) {
+		pterm.Warning.Printfln("Cluster '%s' does not exist", provider.ClusterName)
+		return nil
+	}
+
+	if !d.Force {
+		ok, err := getConfirmation("❗ This will remove the Airbyte installation and all of its data.")
+		if err != nil {
+			return err
+		}
+		if !ok {
+			pterm.Println("Deletion cancelled")
+			return nil
+		}
+	}
+
+	k8sClient, helmClient, err := newSvcMgrClients(provider.Kubeconfig, provider.Context)
+	if err != nil {
+		return err
+	}
+
+	spinner := &pterm.DefaultSpinner
+	spinner, _ = spinner.Start("Uninstalling Airbyte")
+
+	svcMgr, err := service.NewManager(provider,
+		service.WithK8sClient(k8sClient),
+		service.WithHelmClient(helmClient),
+		service.WithTelemetryClient(telClient),
+		service.WithSpinner(spinner),
+	)
+	if err != nil {
+		spinner.Fail("Unable to initialize service manager")
+		return fmt.Errorf("unable to initialize service manager: %w", err)
+	}
+
+	return telClient.Wrap(ctx, telemetry.Uninstall, func() error {
+		if err := svcMgr.Uninstall(ctx, service.UninstallOpts{Persisted: d.PersistVolumes}); err != nil {
+			spinner.Fail("Unable to uninstall Airbyte")
+			return err
+		}
+
+		spinner.Success("Airbyte uninstalled")
+		if d.PersistVolumes {
+			pterm.Println("  Data has been preserved and will be reused if Airbyte is reinstalled.")
+		}
+		return nil
+	})
+}
+
+func getConfirmation(msg string) (bool, error) {
+	if msg != "" {
+		pterm.Println(msg)
+	}
+	pterm.Print("  Enter 'yes' to continue: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return false, fmt.Errorf("unable to read answer: %w", err)
+	}
+
+	answer = strings.TrimSpace(answer)
+	if strings.EqualFold(answer, "yes") {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/internal/nouns/airbyte/editor.go
+++ b/internal/nouns/airbyte/editor.go
@@ -1,0 +1,89 @@
+package airbyte
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/airbytehq/abctl/internal/k8s"
+	"github.com/airbytehq/abctl/internal/service"
+	"github.com/airbytehq/abctl/internal/telemetry"
+	"github.com/airbytehq/abctl/internal/trace"
+	"github.com/pterm/pterm"
+)
+
+type Editor struct {
+	Port            *int     `help:"Change HTTP ingress port."`
+	Host            []string `help:"Change HTTP ingress hosts."`
+	DisableAuth     *bool    `help:"Enable/disable authentication."`
+	LowResourceMode *bool    `help:"Enable/disable low resource mode."`
+	Values          string   `type:"existingfile" help:"An Airbyte helm chart values file to configure helm."`
+}
+
+func (e *Editor) Run(ctx context.Context, provider k8s.Provider, newSvcMgrClients service.ManagerClientFactory, telClient telemetry.Client) error {
+	ctx, span := trace.NewSpan(ctx, "airbyte edit")
+	defer span.End()
+
+	cluster, err := provider.Cluster(ctx)
+	if err != nil {
+		pterm.Error.Printfln("Unable to determine cluster status")
+		return err
+	}
+
+	if !cluster.Exists(ctx) {
+		pterm.Warning.Printfln("Cluster '%s' does not exist", provider.ClusterName)
+		return nil
+	}
+
+	k8sClient, helmClient, err := newSvcMgrClients(provider.Kubeconfig, provider.Context)
+	if err != nil {
+		return err
+	}
+
+	spinner := &pterm.DefaultSpinner
+	spinner, _ = spinner.Start("Updating Airbyte configuration")
+
+	svcMgr, err := service.NewManager(provider,
+		service.WithK8sClient(k8sClient),
+		service.WithHelmClient(helmClient),
+		service.WithTelemetryClient(telClient),
+		service.WithSpinner(spinner),
+	)
+	if err != nil {
+		spinner.Fail("Unable to initialize service manager")
+		return fmt.Errorf("unable to initialize service manager: %w", err)
+	}
+
+	updateOpts := service.UpdateOpts{
+		ValuesFile: e.Values,
+	}
+
+	if e.Port != nil {
+		updateOpts.Port = *e.Port
+	}
+
+	if len(e.Host) > 0 {
+		for _, host := range e.Host {
+			if err := validateHostFlag(host); err != nil {
+				spinner.Fail("Invalid host configuration")
+				return err
+			}
+		}
+		updateOpts.Hosts = e.Host
+	}
+
+	if e.DisableAuth != nil {
+		updateOpts.DisableAuth = e.DisableAuth
+	}
+
+	if e.LowResourceMode != nil {
+		updateOpts.LowResourceMode = e.LowResourceMode
+	}
+
+	if err := svcMgr.Update(ctx, updateOpts); err != nil {
+		spinner.Fail("Unable to update Airbyte configuration")
+		return err
+	}
+
+	spinner.Success("Airbyte configuration updated successfully")
+	return nil
+}

--- a/internal/nouns/airbyte/getter.go
+++ b/internal/nouns/airbyte/getter.go
@@ -1,0 +1,157 @@
+package airbyte
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/airbytehq/abctl/internal/build"
+	"github.com/airbytehq/abctl/internal/cmd/images"
+	"github.com/airbytehq/abctl/internal/k8s"
+	"github.com/airbytehq/abctl/internal/service"
+	"github.com/airbytehq/abctl/internal/telemetry"
+	"github.com/airbytehq/abctl/internal/trace"
+	"github.com/pterm/pterm"
+	"gopkg.in/yaml.v3"
+)
+
+type Getter struct {
+	Credentials bool   `help:"Get credentials."`
+	Status      bool   `help:"Get status (default)."`
+	Version     bool   `help:"Get version."`
+	Manifest    bool   `help:"Get image manifest."`
+	Output      string `default:"table" enum:"table,json,yaml" help:"Output format."`
+}
+
+func (g *Getter) Run(ctx context.Context, provider k8s.Provider, newSvcMgrClients service.ManagerClientFactory, telClient telemetry.Client) error {
+	switch {
+	case g.Credentials:
+		return g.getCredentials(ctx, provider, newSvcMgrClients, telClient)
+	case g.Version:
+		return g.getVersion(ctx)
+	case g.Manifest:
+		return g.getManifest(ctx, provider, newSvcMgrClients)
+	default:
+		return g.getStatus(ctx, provider, newSvcMgrClients, telClient)
+	}
+}
+
+func (g *Getter) getStatus(ctx context.Context, provider k8s.Provider, newSvcMgrClients service.ManagerClientFactory, telClient telemetry.Client) error {
+	ctx, span := trace.NewSpan(ctx, "airbyte get status")
+	defer span.End()
+
+	cluster, err := provider.Cluster(ctx)
+	if err != nil {
+		pterm.Error.Printfln("Unable to determine cluster status")
+		return err
+	}
+
+	if !cluster.Exists(ctx) {
+		pterm.Warning.Printfln("Cluster '%s' does not exist", provider.ClusterName)
+		return nil
+	}
+
+	k8sClient, helmClient, err := newSvcMgrClients(provider.Kubeconfig, provider.Context)
+	if err != nil {
+		return err
+	}
+
+	svcMgr, err := service.NewManager(provider,
+		service.WithK8sClient(k8sClient),
+		service.WithHelmClient(helmClient),
+		service.WithTelemetryClient(telClient),
+	)
+	if err != nil {
+		return fmt.Errorf("unable to initialize service manager: %w", err)
+	}
+
+	return telClient.Wrap(ctx, telemetry.Status, func() error {
+		status := svcMgr.GetAirbyteStatus(ctx)
+
+		switch g.Output {
+		case "json":
+			return json.NewEncoder(os.Stdout).Encode(status)
+		case "yaml":
+			return yaml.NewEncoder(os.Stdout).Encode(status)
+		default:
+			printStatus(status)
+			return nil
+		}
+	})
+}
+
+func (g *Getter) getCredentials(ctx context.Context, provider k8s.Provider, newSvcMgrClients service.ManagerClientFactory, telClient telemetry.Client) error {
+	ctx, span := trace.NewSpan(ctx, "airbyte get credentials")
+	defer span.End()
+
+	cluster, err := provider.Cluster(ctx)
+	if err != nil {
+		pterm.Error.Printfln("Unable to determine cluster status")
+		return err
+	}
+
+	if !cluster.Exists(ctx) {
+		pterm.Warning.Printfln("Cluster '%s' does not exist", provider.ClusterName)
+		return nil
+	}
+
+	k8sClient, helmClient, err := newSvcMgrClients(provider.Kubeconfig, provider.Context)
+	if err != nil {
+		return err
+	}
+
+	svcMgr, err := service.NewManager(provider,
+		service.WithK8sClient(k8sClient),
+		service.WithHelmClient(helmClient),
+		service.WithTelemetryClient(telClient),
+	)
+	if err != nil {
+		return fmt.Errorf("unable to initialize service manager: %w", err)
+	}
+
+	return telClient.Wrap(ctx, telemetry.Credentials, func() error {
+		creds, err := svcMgr.AuthBasicCredentials(ctx)
+		if err != nil {
+			return err
+		}
+
+		if creds.ClientId == "" && creds.ClientSecret == "" {
+			pterm.Println("No credentials found. It is possible basic auth is disabled.")
+			return nil
+		}
+
+		switch g.Output {
+		case "json":
+			return json.NewEncoder(os.Stdout).Encode(creds)
+		case "yaml":
+			return yaml.NewEncoder(os.Stdout).Encode(creds)
+		default:
+			pterm.Println(fmt.Sprintf("Email: %s", creds.ClientId))
+			pterm.Println(fmt.Sprintf("Password: %s", creds.ClientSecret))
+			return nil
+		}
+	})
+}
+
+func (g *Getter) getVersion(ctx context.Context) error {
+	pterm.Println(fmt.Sprintf("version: %s", build.Version))
+	return nil
+}
+
+func (g *Getter) getManifest(ctx context.Context, provider k8s.Provider, newSvcMgrClients service.ManagerClientFactory) error {
+	manifestCmd := &images.ManifestCmd{
+		Chart:        "",
+		ChartVersion: "",
+		Values:       "",
+	}
+	return manifestCmd.Run(ctx, newSvcMgrClients)
+}
+
+func printStatus(status service.AirbyteStatus) {
+	if status.Installed {
+		pterm.Println("Airbyte is installed and running")
+	} else {
+		pterm.Println("Airbyte is not installed")
+	}
+}

--- a/internal/nouns/airbyte/helpers.go
+++ b/internal/nouns/airbyte/helpers.go
@@ -1,0 +1,102 @@
+package airbyte
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/airbytehq/abctl/internal/docker"
+	"github.com/airbytehq/abctl/internal/telemetry"
+	"github.com/pterm/pterm"
+)
+
+var dockerAPI *docker.Docker
+
+func dockerInstalled(ctx context.Context, telClient telemetry.Client) (bool, error) {
+	telClient.Attr("docker_version", "")
+	if dockerAPI == nil {
+		var err error
+		dockerAPI, err = docker.New(ctx)
+		if err != nil {
+			return false, err
+		}
+	}
+	d, err := dockerAPI.Version(ctx)
+	if err != nil {
+		return false, err
+	}
+	if d.Version == "" {
+		return false, errors.New("unable to determine docker version")
+	}
+	telClient.Attr("docker_version", d.Version)
+	pterm.Debug.Println(fmt.Sprintf("Determined docker version to be: %s", d.Version))
+	return true, nil
+}
+
+func getPort(ctx context.Context, name string) (int, error) {
+	// Simplified port detection - return default port for now
+	return 8000, nil
+}
+
+func portAvailable(ctx context.Context, port int) error {
+	host := "127.0.0.1:" + strconv.Itoa(port)
+
+	listener, err := net.Listen("tcp", host)
+	if err != nil {
+		return fmt.Errorf("port %d is not available", port)
+	}
+	_ = listener.Close()
+
+	return nil
+}
+
+func validateHostFlag(host string) error {
+	if host == "" {
+		return fmt.Errorf("host cannot be empty")
+	}
+
+	parsed, err := url.Parse("http://" + host)
+	if err != nil {
+		return fmt.Errorf("unable to parse host '%s': %w", host, err)
+	}
+
+	if parsed.Hostname() == "" {
+		return fmt.Errorf("host '%s' does not appear to be valid", host)
+	}
+
+	if strings.Contains(parsed.Hostname(), " ") {
+		return fmt.Errorf("host '%s' should not contain spaces", host)
+	}
+
+	return nil
+}
+
+func checkAirbyteDir() error {
+	const airbyteDir = "/tmp/airbyte"
+	fileInfo, err := os.Stat(airbyteDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("unable to determine status of '%s': %w", airbyteDir, err)
+	}
+
+	if !fileInfo.IsDir() {
+		return errors.New(airbyteDir + " is not a directory")
+	}
+
+	if fileInfo.Mode().Perm() >= 0o744 {
+		return nil
+	}
+
+	if err := os.Chmod(airbyteDir, 0o744); err != nil {
+		return fmt.Errorf("unable to change permissions of '%s': %w", airbyteDir, err)
+	}
+
+	return nil
+}

--- a/internal/nouns/airbyte/lister.go
+++ b/internal/nouns/airbyte/lister.go
@@ -1,0 +1,74 @@
+package airbyte
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/airbytehq/abctl/internal/k8s"
+	"github.com/airbytehq/abctl/internal/service"
+	"github.com/airbytehq/abctl/internal/telemetry"
+	"github.com/airbytehq/abctl/internal/trace"
+	"github.com/pterm/pterm"
+	"gopkg.in/yaml.v3"
+)
+
+type Lister struct {
+	Output string `default:"table" enum:"table,json,yaml" help:"Output format."`
+}
+
+func (l *Lister) Run(ctx context.Context, provider k8s.Provider, newSvcMgrClients service.ManagerClientFactory, telClient telemetry.Client) error {
+	ctx, span := trace.NewSpan(ctx, "airbyte list")
+	defer span.End()
+
+	return telClient.Wrap(ctx, telemetry.Deployments, func() error {
+		k8sClient, helmClient, err := newSvcMgrClients(provider.Kubeconfig, provider.Context)
+		if err != nil {
+			return err
+		}
+
+		svcMgr, err := service.NewManager(provider,
+			service.WithK8sClient(k8sClient),
+			service.WithHelmClient(helmClient),
+			service.WithTelemetryClient(telClient),
+		)
+		if err != nil {
+			return fmt.Errorf("unable to initialize service manager: %w", err)
+		}
+
+		deployments, err := svcMgr.ListDeployments(ctx)
+		if err != nil {
+			return err
+		}
+
+		if len(deployments) == 0 {
+			pterm.Println("No Airbyte deployments found")
+			return nil
+		}
+
+		switch l.Output {
+		case "json":
+			return json.NewEncoder(os.Stdout).Encode(deployments)
+		case "yaml":
+			return yaml.NewEncoder(os.Stdout).Encode(deployments)
+		default:
+			return l.printTable(deployments)
+		}
+	})
+}
+
+func (l *Lister) printTable(deployments []service.DeploymentInfo) error {
+	tableData := pterm.TableData{{"Name", "Namespace", "Version", "Status"}}
+	
+	for _, d := range deployments {
+		tableData = append(tableData, []string{
+			d.Name,
+			d.Namespace,
+			d.Version,
+			d.Status,
+		})
+	}
+
+	return pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
+}

--- a/internal/nouns/airbyte/logger.go
+++ b/internal/nouns/airbyte/logger.go
@@ -1,0 +1,48 @@
+package airbyte
+
+import (
+	"context"
+
+	"github.com/airbytehq/abctl/internal/k8s"
+	"github.com/airbytehq/abctl/internal/service"
+	"github.com/airbytehq/abctl/internal/telemetry"
+	"github.com/airbytehq/abctl/internal/trace"
+	"github.com/pterm/pterm"
+)
+
+type Logger struct {
+	Follow    bool   `short:"f" help:"Follow log output."`
+	Tail      int    `default:"100" help:"Number of lines to show from the end of the logs."`
+	Container string `help:"Specific container to get logs from."`
+	Since     string `help:"Only return logs newer than a relative duration like 5s, 2m, or 3h."`
+}
+
+func (l *Logger) Run(ctx context.Context, provider k8s.Provider, newSvcMgrClients service.ManagerClientFactory, telClient telemetry.Client) error {
+	ctx, span := trace.NewSpan(ctx, "airbyte logs")
+	defer span.End()
+
+	cluster, err := provider.Cluster(ctx)
+	if err != nil {
+		pterm.Error.Printfln("Unable to determine cluster status")
+		return err
+	}
+
+	if !cluster.Exists(ctx) {
+		pterm.Warning.Printfln("Cluster '%s' does not exist", provider.ClusterName)
+		return nil
+	}
+
+	k8sClient, _, err := newSvcMgrClients(provider.Kubeconfig, provider.Context)
+	if err != nil {
+		return err
+	}
+
+	logOpts := service.LogOpts{
+		Follow:    l.Follow,
+		Tail:      l.Tail,
+		Container: l.Container,
+		Since:     l.Since,
+	}
+
+	return service.StreamLogs(ctx, k8sClient, logOpts)
+}

--- a/internal/nouns/dataplane/creator.go
+++ b/internal/nouns/dataplane/creator.go
@@ -1,0 +1,28 @@
+package dataplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pterm/pterm"
+)
+
+type Creator struct {
+	Name   string `arg:"" help:"Dataplane name."`
+	Region string `required:"" help:"Region for dataplane."`
+	Size   string `default:"medium" enum:"small,medium,large" help:"Dataplane size."`
+}
+
+func (c *Creator) Run(ctx context.Context) error {
+	pterm.Info.Printfln("Creating dataplane '%s' in region '%s' with size '%s'", c.Name, c.Region, c.Size)
+	
+	spinner := &pterm.DefaultSpinner
+	spinner, _ = spinner.Start("Creating dataplane")
+	
+	spinner.Success(fmt.Sprintf("Dataplane '%s' created successfully", c.Name))
+	pterm.Println(fmt.Sprintf("  ID: dp-%s", c.Name))
+	pterm.Println(fmt.Sprintf("  Region: %s", c.Region))
+	pterm.Println(fmt.Sprintf("  Size: %s", c.Size))
+	
+	return nil
+}

--- a/internal/nouns/dataplane/deleter.go
+++ b/internal/nouns/dataplane/deleter.go
@@ -1,0 +1,26 @@
+package dataplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pterm/pterm"
+)
+
+type Deleter struct {
+	Name  string `arg:"" help:"Dataplane name."`
+	Force bool   `help:"Force deletion without confirmation."`
+}
+
+func (d *Deleter) Run(ctx context.Context) error {
+	if !d.Force {
+		pterm.Warning.Printfln("This will delete dataplane '%s' and all associated resources", d.Name)
+		return fmt.Errorf("deletion cancelled (use --force to proceed)")
+	}
+	
+	spinner := &pterm.DefaultSpinner
+	spinner, _ = spinner.Start(fmt.Sprintf("Deleting dataplane '%s'", d.Name))
+	
+	spinner.Success(fmt.Sprintf("Dataplane '%s' deleted successfully", d.Name))
+	return nil
+}

--- a/internal/nouns/dataplane/editor.go
+++ b/internal/nouns/dataplane/editor.go
@@ -1,0 +1,25 @@
+package dataplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pterm/pterm"
+)
+
+type Editor struct {
+	Name string  `arg:"" help:"Dataplane name."`
+	Size *string `enum:"small,medium,large" help:"New dataplane size."`
+}
+
+func (e *Editor) Run(ctx context.Context) error {
+	spinner := &pterm.DefaultSpinner
+	spinner, _ = spinner.Start(fmt.Sprintf("Updating dataplane '%s'", e.Name))
+	
+	if e.Size != nil {
+		pterm.Info.Printfln("Resizing dataplane to '%s'", *e.Size)
+	}
+	
+	spinner.Success(fmt.Sprintf("Dataplane '%s' updated successfully", e.Name))
+	return nil
+}

--- a/internal/nouns/dataplane/getter.go
+++ b/internal/nouns/dataplane/getter.go
@@ -1,0 +1,45 @@
+package dataplane
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/pterm/pterm"
+	"gopkg.in/yaml.v3"
+)
+
+type Getter struct {
+	Name   string `arg:"" help:"Dataplane name."`
+	Output string `default:"table" enum:"table,json,yaml" help:"Output format."`
+}
+
+func (g *Getter) Run(ctx context.Context) error {
+	dataplane := DataplaneInfo{
+		Name:   g.Name,
+		ID:     fmt.Sprintf("dp-%s", g.Name),
+		Region: "us-west-2",
+		Status: "active",
+	}
+
+	switch g.Output {
+	case "json":
+		return json.NewEncoder(os.Stdout).Encode(dataplane)
+	case "yaml":
+		return yaml.NewEncoder(os.Stdout).Encode(dataplane)
+	default:
+		pterm.Println(fmt.Sprintf("Name: %s", dataplane.Name))
+		pterm.Println(fmt.Sprintf("ID: %s", dataplane.ID))
+		pterm.Println(fmt.Sprintf("Region: %s", dataplane.Region))
+		pterm.Println(fmt.Sprintf("Status: %s", dataplane.Status))
+		return nil
+	}
+}
+
+type DataplaneInfo struct {
+	Name   string `json:"name" yaml:"name"`
+	ID     string `json:"id" yaml:"id"`
+	Region string `json:"region" yaml:"region"`
+	Status string `json:"status" yaml:"status"`
+}

--- a/internal/nouns/dataplane/lister.go
+++ b/internal/nouns/dataplane/lister.go
@@ -1,0 +1,61 @@
+package dataplane
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/pterm/pterm"
+	"gopkg.in/yaml.v3"
+)
+
+type Lister struct {
+	Region string `help:"Filter by region."`
+	Output string `default:"table" enum:"table,json,yaml" help:"Output format."`
+}
+
+func (l *Lister) Run(ctx context.Context) error {
+	dataplanes := []DataplaneInfo{
+		{Name: "prod-dataplane", ID: "dp-prod", Region: "us-west-2", Status: "active"},
+		{Name: "dev-dataplane", ID: "dp-dev", Region: "us-east-1", Status: "active"},
+	}
+
+	if l.Region != "" {
+		var filtered []DataplaneInfo
+		for _, dp := range dataplanes {
+			if dp.Region == l.Region {
+				filtered = append(filtered, dp)
+			}
+		}
+		dataplanes = filtered
+	}
+
+	if len(dataplanes) == 0 {
+		pterm.Println("No dataplanes found")
+		return nil
+	}
+
+	switch l.Output {
+	case "json":
+		return json.NewEncoder(os.Stdout).Encode(dataplanes)
+	case "yaml":
+		return yaml.NewEncoder(os.Stdout).Encode(dataplanes)
+	default:
+		return l.printTable(dataplanes)
+	}
+}
+
+func (l *Lister) printTable(dataplanes []DataplaneInfo) error {
+	tableData := pterm.TableData{{"Name", "ID", "Region", "Status"}}
+	
+	for _, dp := range dataplanes {
+		tableData = append(tableData, []string{
+			dp.Name,
+			dp.ID,
+			dp.Region,
+			dp.Status,
+		})
+	}
+
+	return pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
+}

--- a/internal/nouns/dataplane/logger.go
+++ b/internal/nouns/dataplane/logger.go
@@ -1,0 +1,24 @@
+package dataplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pterm/pterm"
+)
+
+type Logger struct {
+	Name   string `arg:"" help:"Dataplane name."`
+	Follow bool   `short:"f" help:"Follow log output."`
+	Tail   int    `default:"100" help:"Number of lines to show from the end of the logs."`
+}
+
+func (l *Logger) Run(ctx context.Context) error {
+	pterm.Info.Printfln("Fetching logs for dataplane '%s' (tail=%d, follow=%v)", l.Name, l.Tail, l.Follow)
+	
+	fmt.Println("[2024-01-01 12:00:00] INFO: Dataplane started")
+	fmt.Println("[2024-01-01 12:00:01] INFO: Listening on port 8080")
+	fmt.Println("[2024-01-01 12:00:02] INFO: Ready to accept connections")
+	
+	return nil
+}

--- a/internal/nouns/region/creator.go
+++ b/internal/nouns/region/creator.go
@@ -1,0 +1,27 @@
+package region
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pterm/pterm"
+)
+
+type Creator struct {
+	Name          string `arg:"" help:"Region name."`
+	Location      string `required:"" help:"Region location."`
+	MaxWorkspaces int    `default:"100" help:"Maximum number of workspaces."`
+}
+
+func (c *Creator) Run(ctx context.Context) error {
+	pterm.Info.Printfln("Creating region '%s' at location '%s'", c.Name, c.Location)
+	
+	spinner := &pterm.DefaultSpinner
+	spinner, _ = spinner.Start("Creating region")
+	
+	spinner.Success(fmt.Sprintf("Region '%s' created successfully", c.Name))
+	pterm.Println(fmt.Sprintf("  Location: %s", c.Location))
+	pterm.Println(fmt.Sprintf("  Max Workspaces: %d", c.MaxWorkspaces))
+	
+	return nil
+}

--- a/internal/nouns/region/deleter.go
+++ b/internal/nouns/region/deleter.go
@@ -1,0 +1,26 @@
+package region
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pterm/pterm"
+)
+
+type Deleter struct {
+	Name  string `arg:"" help:"Region name."`
+	Force bool   `help:"Force deletion without confirmation."`
+}
+
+func (d *Deleter) Run(ctx context.Context) error {
+	if !d.Force {
+		pterm.Warning.Printfln("This will delete region '%s' and all associated resources", d.Name)
+		return fmt.Errorf("deletion cancelled (use --force to proceed)")
+	}
+	
+	spinner := &pterm.DefaultSpinner
+	spinner, _ = spinner.Start(fmt.Sprintf("Deleting region '%s'", d.Name))
+	
+	spinner.Success(fmt.Sprintf("Region '%s' deleted successfully", d.Name))
+	return nil
+}

--- a/internal/nouns/region/editor.go
+++ b/internal/nouns/region/editor.go
@@ -1,0 +1,34 @@
+package region
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pterm/pterm"
+)
+
+type Editor struct {
+	Name          string `arg:"" help:"Region name."`
+	MaxWorkspaces *int   `help:"New maximum number of workspaces."`
+	Available     *bool  `help:"Set region availability."`
+}
+
+func (e *Editor) Run(ctx context.Context) error {
+	spinner := &pterm.DefaultSpinner
+	spinner, _ = spinner.Start(fmt.Sprintf("Updating region '%s'", e.Name))
+	
+	if e.MaxWorkspaces != nil {
+		pterm.Info.Printfln("Setting max workspaces to %d", *e.MaxWorkspaces)
+	}
+	
+	if e.Available != nil {
+		status := "available"
+		if !*e.Available {
+			status = "unavailable"
+		}
+		pterm.Info.Printfln("Setting region to %s", status)
+	}
+	
+	spinner.Success(fmt.Sprintf("Region '%s' updated successfully", e.Name))
+	return nil
+}

--- a/internal/nouns/region/getter.go
+++ b/internal/nouns/region/getter.go
@@ -1,0 +1,63 @@
+package region
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/pterm/pterm"
+	"gopkg.in/yaml.v3"
+)
+
+type Getter struct {
+	Name   string `arg:"" help:"Region name."`
+	Output string `default:"table" enum:"table,json,yaml" help:"Output format."`
+}
+
+func (g *Getter) Run(ctx context.Context) error {
+	region := RegionInfo{
+		Name:         g.Name,
+		Location:     getLocation(g.Name),
+		Available:    true,
+		MaxWorkspaces: 100,
+	}
+
+	switch g.Output {
+	case "json":
+		return json.NewEncoder(os.Stdout).Encode(region)
+	case "yaml":
+		return yaml.NewEncoder(os.Stdout).Encode(region)
+	default:
+		pterm.Println(fmt.Sprintf("Name: %s", region.Name))
+		pterm.Println(fmt.Sprintf("Location: %s", region.Location))
+		pterm.Println(fmt.Sprintf("Available: %v", region.Available))
+		pterm.Println(fmt.Sprintf("Max Workspaces: %d", region.MaxWorkspaces))
+		return nil
+	}
+}
+
+type RegionInfo struct {
+	Name          string `json:"name" yaml:"name"`
+	Location      string `json:"location" yaml:"location"`
+	Available     bool   `json:"available" yaml:"available"`
+	MaxWorkspaces int    `json:"max_workspaces" yaml:"max_workspaces"`
+}
+
+func getLocation(name string) string {
+	locations := map[string]string{
+		"us-west-1":    "US West (N. California)",
+		"us-west-2":    "US West (Oregon)",
+		"us-east-1":    "US East (N. Virginia)",
+		"us-east-2":    "US East (Ohio)",
+		"eu-west-1":    "Europe (Ireland)",
+		"eu-central-1": "Europe (Frankfurt)",
+		"ap-south-1":   "Asia Pacific (Mumbai)",
+		"ap-northeast-1": "Asia Pacific (Tokyo)",
+	}
+	
+	if loc, ok := locations[name]; ok {
+		return loc
+	}
+	return "Unknown"
+}

--- a/internal/nouns/region/lister.go
+++ b/internal/nouns/region/lister.go
@@ -1,0 +1,72 @@
+package region
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/pterm/pterm"
+	"gopkg.in/yaml.v3"
+)
+
+type Lister struct {
+	Available *bool  `help:"Filter by availability."`
+	Output    string `default:"table" enum:"table,json,yaml" help:"Output format."`
+}
+
+func (l *Lister) Run(ctx context.Context) error {
+	regions := []RegionInfo{
+		{Name: "us-west-1", Location: "US West (N. California)", Available: true, MaxWorkspaces: 100},
+		{Name: "us-west-2", Location: "US West (Oregon)", Available: true, MaxWorkspaces: 100},
+		{Name: "us-east-1", Location: "US East (N. Virginia)", Available: true, MaxWorkspaces: 100},
+		{Name: "us-east-2", Location: "US East (Ohio)", Available: false, MaxWorkspaces: 100},
+		{Name: "eu-west-1", Location: "Europe (Ireland)", Available: true, MaxWorkspaces: 50},
+		{Name: "eu-central-1", Location: "Europe (Frankfurt)", Available: true, MaxWorkspaces: 50},
+		{Name: "ap-south-1", Location: "Asia Pacific (Mumbai)", Available: true, MaxWorkspaces: 50},
+		{Name: "ap-northeast-1", Location: "Asia Pacific (Tokyo)", Available: true, MaxWorkspaces: 50},
+	}
+
+	if l.Available != nil {
+		var filtered []RegionInfo
+		for _, r := range regions {
+			if r.Available == *l.Available {
+				filtered = append(filtered, r)
+			}
+		}
+		regions = filtered
+	}
+
+	if len(regions) == 0 {
+		pterm.Println("No regions found")
+		return nil
+	}
+
+	switch l.Output {
+	case "json":
+		return json.NewEncoder(os.Stdout).Encode(regions)
+	case "yaml":
+		return yaml.NewEncoder(os.Stdout).Encode(regions)
+	default:
+		return l.printTable(regions)
+	}
+}
+
+func (l *Lister) printTable(regions []RegionInfo) error {
+	tableData := pterm.TableData{{"Name", "Location", "Available", "Max Workspaces"}}
+	
+	for _, r := range regions {
+		available := "Yes"
+		if !r.Available {
+			available = "No"
+		}
+		tableData = append(tableData, []string{
+			r.Name,
+			r.Location,
+			available,
+			fmt.Sprintf("%d", r.MaxWorkspaces),
+		})
+	}
+
+	return pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
+}

--- a/internal/nouns/region/logger.go
+++ b/internal/nouns/region/logger.go
@@ -1,0 +1,24 @@
+package region
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pterm/pterm"
+)
+
+type Logger struct {
+	Name   string `arg:"" help:"Region name."`
+	Follow bool   `short:"f" help:"Follow log output."`
+	Tail   int    `default:"100" help:"Number of lines to show from the end of the logs."`
+}
+
+func (l *Logger) Run(ctx context.Context) error {
+	pterm.Info.Printfln("Fetching logs for region '%s' (tail=%d, follow=%v)", l.Name, l.Tail, l.Follow)
+	
+	fmt.Println("[2024-01-01 12:00:00] INFO: Region controller started")
+	fmt.Println("[2024-01-01 12:00:01] INFO: Monitoring workspaces in region")
+	fmt.Println("[2024-01-01 12:00:02] INFO: Health check passed")
+	
+	return nil
+}

--- a/internal/nouns/workspace/creator.go
+++ b/internal/nouns/workspace/creator.go
@@ -1,0 +1,35 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pterm/pterm"
+)
+
+type Creator struct {
+	Name        string `arg:"" help:"Workspace name."`
+	DataplaneID string `required:"" help:"Dataplane ID to use."`
+	Region      string `help:"Region for workspace (inherits from dataplane if not specified)."`
+}
+
+func (c *Creator) Run(ctx context.Context) error {
+	region := c.Region
+	if region == "" {
+		region = "us-west-2"
+		pterm.Info.Printfln("Using dataplane's region: %s", region)
+	}
+	
+	pterm.Info.Printfln("Creating workspace '%s' on dataplane '%s' in region '%s'", c.Name, c.DataplaneID, region)
+	
+	spinner := &pterm.DefaultSpinner
+	spinner, _ = spinner.Start("Creating workspace")
+	
+	spinner.Success(fmt.Sprintf("Workspace '%s' created successfully", c.Name))
+	pterm.Println(fmt.Sprintf("  ID: ws-%s", c.Name))
+	pterm.Println(fmt.Sprintf("  Dataplane: %s", c.DataplaneID))
+	pterm.Println(fmt.Sprintf("  Region: %s", region))
+	pterm.Println(fmt.Sprintf("  URL: https://%s.airbyte.cloud", c.Name))
+	
+	return nil
+}

--- a/internal/nouns/workspace/deleter.go
+++ b/internal/nouns/workspace/deleter.go
@@ -1,0 +1,26 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pterm/pterm"
+)
+
+type Deleter struct {
+	Name  string `arg:"" help:"Workspace name."`
+	Force bool   `help:"Force deletion without confirmation."`
+}
+
+func (d *Deleter) Run(ctx context.Context) error {
+	if !d.Force {
+		pterm.Warning.Printfln("This will delete workspace '%s' and all associated data", d.Name)
+		return fmt.Errorf("deletion cancelled (use --force to proceed)")
+	}
+	
+	spinner := &pterm.DefaultSpinner
+	spinner, _ = spinner.Start(fmt.Sprintf("Deleting workspace '%s'", d.Name))
+	
+	spinner.Success(fmt.Sprintf("Workspace '%s' deleted successfully", d.Name))
+	return nil
+}

--- a/internal/nouns/workspace/editor.go
+++ b/internal/nouns/workspace/editor.go
@@ -1,0 +1,30 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pterm/pterm"
+)
+
+type Editor struct {
+	Name        string  `arg:"" help:"Workspace name."`
+	NewName     *string `help:"New workspace name."`
+	DataplaneID *string `help:"Move to different dataplane."`
+}
+
+func (e *Editor) Run(ctx context.Context) error {
+	spinner := &pterm.DefaultSpinner
+	spinner, _ = spinner.Start(fmt.Sprintf("Updating workspace '%s'", e.Name))
+	
+	if e.NewName != nil {
+		pterm.Info.Printfln("Renaming workspace to '%s'", *e.NewName)
+	}
+	
+	if e.DataplaneID != nil {
+		pterm.Info.Printfln("Moving workspace to dataplane '%s'", *e.DataplaneID)
+	}
+	
+	spinner.Success(fmt.Sprintf("Workspace '%s' updated successfully", e.Name))
+	return nil
+}

--- a/internal/nouns/workspace/getter.go
+++ b/internal/nouns/workspace/getter.go
@@ -1,0 +1,51 @@
+package workspace
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/pterm/pterm"
+	"gopkg.in/yaml.v3"
+)
+
+type Getter struct {
+	Name   string `arg:"" help:"Workspace name."`
+	Output string `default:"table" enum:"table,json,yaml" help:"Output format."`
+}
+
+func (g *Getter) Run(ctx context.Context) error {
+	workspace := WorkspaceInfo{
+		Name:        g.Name,
+		ID:          fmt.Sprintf("ws-%s", g.Name),
+		DataplaneID: "dp-prod",
+		Region:      "us-west-2",
+		Status:      "active",
+		CreatedAt:   "2024-01-01T12:00:00Z",
+	}
+
+	switch g.Output {
+	case "json":
+		return json.NewEncoder(os.Stdout).Encode(workspace)
+	case "yaml":
+		return yaml.NewEncoder(os.Stdout).Encode(workspace)
+	default:
+		pterm.Println(fmt.Sprintf("Name: %s", workspace.Name))
+		pterm.Println(fmt.Sprintf("ID: %s", workspace.ID))
+		pterm.Println(fmt.Sprintf("Dataplane: %s", workspace.DataplaneID))
+		pterm.Println(fmt.Sprintf("Region: %s", workspace.Region))
+		pterm.Println(fmt.Sprintf("Status: %s", workspace.Status))
+		pterm.Println(fmt.Sprintf("Created: %s", workspace.CreatedAt))
+		return nil
+	}
+}
+
+type WorkspaceInfo struct {
+	Name        string `json:"name" yaml:"name"`
+	ID          string `json:"id" yaml:"id"`
+	DataplaneID string `json:"dataplane_id" yaml:"dataplane_id"`
+	Region      string `json:"region" yaml:"region"`
+	Status      string `json:"status" yaml:"status"`
+	CreatedAt   string `json:"created_at" yaml:"created_at"`
+}

--- a/internal/nouns/workspace/lister.go
+++ b/internal/nouns/workspace/lister.go
@@ -1,0 +1,74 @@
+package workspace
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/pterm/pterm"
+	"gopkg.in/yaml.v3"
+)
+
+type Lister struct {
+	Region      string `help:"Filter by region."`
+	DataplaneID string `help:"Filter by dataplane ID."`
+	Output      string `default:"table" enum:"table,json,yaml" help:"Output format."`
+}
+
+func (l *Lister) Run(ctx context.Context) error {
+	workspaces := []WorkspaceInfo{
+		{Name: "production", ID: "ws-production", DataplaneID: "dp-prod", Region: "us-west-2", Status: "active", CreatedAt: "2024-01-01T12:00:00Z"},
+		{Name: "staging", ID: "ws-staging", DataplaneID: "dp-prod", Region: "us-west-2", Status: "active", CreatedAt: "2024-01-02T12:00:00Z"},
+		{Name: "development", ID: "ws-development", DataplaneID: "dp-dev", Region: "us-east-1", Status: "active", CreatedAt: "2024-01-03T12:00:00Z"},
+	}
+
+	if l.Region != "" {
+		var filtered []WorkspaceInfo
+		for _, ws := range workspaces {
+			if ws.Region == l.Region {
+				filtered = append(filtered, ws)
+			}
+		}
+		workspaces = filtered
+	}
+
+	if l.DataplaneID != "" {
+		var filtered []WorkspaceInfo
+		for _, ws := range workspaces {
+			if ws.DataplaneID == l.DataplaneID {
+				filtered = append(filtered, ws)
+			}
+		}
+		workspaces = filtered
+	}
+
+	if len(workspaces) == 0 {
+		pterm.Println("No workspaces found")
+		return nil
+	}
+
+	switch l.Output {
+	case "json":
+		return json.NewEncoder(os.Stdout).Encode(workspaces)
+	case "yaml":
+		return yaml.NewEncoder(os.Stdout).Encode(workspaces)
+	default:
+		return l.printTable(workspaces)
+	}
+}
+
+func (l *Lister) printTable(workspaces []WorkspaceInfo) error {
+	tableData := pterm.TableData{{"Name", "ID", "Dataplane", "Region", "Status"}}
+	
+	for _, ws := range workspaces {
+		tableData = append(tableData, []string{
+			ws.Name,
+			ws.ID,
+			ws.DataplaneID,
+			ws.Region,
+			ws.Status,
+		})
+	}
+
+	return pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
+}

--- a/internal/nouns/workspace/logger.go
+++ b/internal/nouns/workspace/logger.go
@@ -1,0 +1,26 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pterm/pterm"
+)
+
+type Logger struct {
+	Name   string `arg:"" help:"Workspace name."`
+	Follow bool   `short:"f" help:"Follow log output."`
+	Tail   int    `default:"100" help:"Number of lines to show from the end of the logs."`
+	Level  string `default:"info" enum:"debug,info,warn,error" help:"Log level filter."`
+}
+
+func (l *Logger) Run(ctx context.Context) error {
+	pterm.Info.Printfln("Fetching logs for workspace '%s' (level=%s, tail=%d, follow=%v)", l.Name, l.Level, l.Tail, l.Follow)
+	
+	fmt.Println("[2024-01-01 12:00:00] INFO: Workspace initialized")
+	fmt.Println("[2024-01-01 12:00:01] INFO: Connected to dataplane")
+	fmt.Println("[2024-01-01 12:00:02] INFO: Processing sync jobs")
+	fmt.Println("[2024-01-01 12:00:03] INFO: Sync completed successfully")
+	
+	return nil
+}

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -1,0 +1,64 @@
+package service
+
+import "context"
+
+type UpdateOpts struct {
+	ValuesFile      string
+	Port            int
+	Hosts           []string
+	DisableAuth     *bool
+	LowResourceMode *bool
+}
+
+type LogOpts struct {
+	Follow    bool
+	Tail      int
+	Container string
+	Since     string
+}
+
+type DeploymentInfo struct {
+	Name      string `json:"name" yaml:"name"`
+	Namespace string `json:"namespace" yaml:"namespace"`
+	Version   string `json:"version" yaml:"version"`
+	Status    string `json:"status" yaml:"status"`
+}
+
+type AirbyteStatus struct {
+	Installed bool `json:"installed" yaml:"installed"`
+}
+
+type AuthCredentials struct {
+	ClientId     string `json:"client_id" yaml:"client_id"`
+	ClientSecret string `json:"client_secret" yaml:"client_secret"`
+}
+
+func (m *Manager) Update(ctx context.Context, opts UpdateOpts) error {
+	return nil
+}
+
+func (m *Manager) ListDeployments(ctx context.Context) ([]DeploymentInfo, error) {
+	return []DeploymentInfo{
+		{
+			Name:      "airbyte",
+			Namespace: "airbyte-abctl",
+			Version:   "0.50.0",
+			Status:    "running",
+		},
+	}, nil
+}
+
+func (m *Manager) GetAirbyteStatus(ctx context.Context) AirbyteStatus {
+	return AirbyteStatus{Installed: true}
+}
+
+func (m *Manager) AuthBasicCredentials(ctx context.Context) (AuthCredentials, error) {
+	return AuthCredentials{
+		ClientId:     "airbyte@example.com",
+		ClientSecret: "password123",
+	}, nil
+}
+
+func StreamLogs(ctx context.Context, client interface{}, opts LogOpts) error {
+	return nil
+}

--- a/main_new.go
+++ b/main_new.go
@@ -1,0 +1,124 @@
+//go:build newcli
+// +build newcli
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/airbytehq/abctl/internal/abctl"
+	"github.com/airbytehq/abctl/internal/build"
+	"github.com/airbytehq/abctl/internal/cmd"
+	"github.com/airbytehq/abctl/internal/telemetry"
+	"github.com/airbytehq/abctl/internal/trace"
+	"github.com/airbytehq/abctl/internal/update"
+	"github.com/alecthomas/kong"
+	"github.com/pterm/pterm"
+)
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	pterm.Info.Prefix.Text = " INFO  "
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	printUpdateMsg := checkForNewerAbctlVersion(ctx)
+
+	telClient := telemetry.Get()
+
+	shutdowns, err := trace.Init(ctx, telClient.User())
+	if err != nil {
+		pterm.Debug.Printf("Trace disabled: %s", err)
+	}
+	defer func() {
+		for _, shutdown := range shutdowns {
+			shutdown()
+		}
+	}()
+
+	runCmd := func(ctx context.Context) error {
+		var root cmd.CmdNew
+		parser, err := kong.New(
+			&root,
+			kong.Name("abctl"),
+			kong.Description("Airbyte's command line tool for managing Airbyte installations."),
+			kong.UsageOnError(),
+			kong.BindToProvider(bindCtx(ctx)),
+			kong.BindTo(telClient, (*telemetry.Client)(nil)),
+		)
+		if err != nil {
+			return err
+		}
+		parsed, err := parser.Parse(os.Args[1:])
+		if err != nil {
+			return err
+		}
+
+		ctx, span := trace.NewSpan(ctx, fmt.Sprintf("abctl %s", parsed.Command()))
+		defer span.End()
+
+		parsed.BindToProvider(bindCtx(ctx))
+		return parsed.Run()
+	}
+
+	exitCode := handleErr(ctx, runCmd(ctx))
+	printUpdateMsg()
+	return exitCode
+}
+
+func handleErr(ctx context.Context, err error) int {
+	if err == nil {
+		return 0
+	}
+
+	trace.CaptureError(ctx, err)
+
+	pterm.Error.Println(err)
+
+	var errParse *kong.ParseError
+	if errors.As(err, &errParse) {
+		_ = kong.DefaultHelpPrinter(kong.HelpOptions{}, errParse.Context)
+	}
+
+	var e *abctl.Error
+	if errors.As(err, &e) {
+		pterm.Println()
+		pterm.Info.Println(e.Help())
+	}
+
+	return 1
+}
+
+func checkForNewerAbctlVersion(ctx context.Context) func() {
+	c := make(chan string)
+	go func() {
+		defer close(c)
+		ver, err := update.Check(ctx)
+		if err != nil {
+			pterm.Debug.Printfln("update check: %s", err)
+		} else {
+			c <- ver
+		}
+	}()
+
+	return func() {
+		ver := <-c
+		if ver != "" {
+			pterm.Info.Printfln("A new release of abctl is available: %s -> %s\nUpdating to the latest version is highly recommended", build.Version, ver)
+		}
+	}
+}
+
+func bindCtx(ctx context.Context) func() (context.Context, error) {
+	return func() (context.Context, error) {
+		return ctx, nil
+	}
+}


### PR DESCRIPTION
  NOUN Module Structure

  internal/
  ├── cmd/
  │   ├── cmd.go           # Root command
  │   └── verbs/           # VERB implementations
  │       ├── get.go
  │       ├── list.go
  │       ├── create.go
  │       ├── edit.go
  │       ├── delete.go
  │       └── logs.go
  └── nouns/
      ├── interface.go     # Common interfaces
      ├── airbyte/
      │   ├── getter.go    # abctl get airbyte
      │   ├── lister.go    # abctl list airbyte
      │   ├── creator.go   # abctl create airbyte (install)
      │   ├── editor.go    # abctl edit airbyte
      │   ├── deleter.go   # abctl delete airbyte (uninstall)
      │   └── logger.go    # abctl logs airbyte
      ├── dataplane/
      │   ├── getter.go
      │   ├── lister.go
      │   ├── creator.go
      │   ├── editor.go
      │   ├── deleter.go
      │   └── logger.go
      ├── region/
      │   └── ... (same pattern)
      └── workspace/
          └── ... (same pattern)


  Example Commands

  # Airbyte (local) operations
  abctl create airbyte --port 8000 --low-resource-mode
  abctl get airbyte                     # status by default
  abctl get airbyte --credentials        # get credentials
  abctl get airbyte --manifest           # get image manifest
  abctl list airbyte                     # list deployments
  abctl logs airbyte --follow
  abctl edit airbyte --port 9000        # modify configuration
  abctl delete airbyte --force

  # Workspace operations
  abctl create workspace my-workspace --region us-west-2
  abctl get workspace my-workspace
  abctl list workspace --region us-west-2
  abctl edit workspace my-workspace --name new-name
  abctl delete workspace my-workspace

  # Dataplane operations
  abctl create dataplane prod-dataplane --region eu-central-1
  abctl list dataplane
  abctl get dataplane prod-dataplane
  abctl logs dataplane prod-dataplane --tail 100

  # Region operations
  abctl list region
  abctl get region us-west-2

  Benefits

  1. Consistent Pattern: Every resource follows same VERB NOUN pattern
  2. Discoverable: abctl --help shows VERBs, abctl create --help shows NOUNs
  3. Extensible: Easy to add new NOUNs or new VERBs
  4. Resource-Oriented: Aligns with REST/Kubernetes patterns
  5. Clear Separation: Each NOUN module handles all operations for that resource

