### PR TITLE
fix: --insecure-cookies broke for v2 charts

### DIFF
--- a/internal/helm/airbyte_values.go
+++ b/internal/helm/airbyte_values.go
@@ -168,7 +168,7 @@ func buildAirbyteValuesV2(ctx context.Context, opts ValuesOpts) (string, error) 
 
 	if opts.InsecureCookies {
 		// Boolean is a string value in the v1 Helm chart.
-		vals = append(vals, `global.auth.cookieSecureSetting="false"`)
+		vals = append(vals, `global.auth.security.cookieSecureSetting="false"`)
 	}
 
 	fileVals, err := maps.FromYAMLFile(opts.ValuesFile)

--- a/internal/helm/airbyte_values_test.go
+++ b/internal/helm/airbyte_values_test.go
@@ -244,7 +244,8 @@ connectorBuilderServer:
     enabled: false
 global:
     auth:
-        cookieSecureSetting: '"false"'
+        security:
+            cookieSecureSetting: '"false"'
         enabled: true
     env_vars:
         AIRBYTE_INSTALLATION_ID: test-user


### PR DESCRIPTION
path to the `cookieSecureSetting` setting changed with v2 charts, so update abctl accordingly