### PR TITLE
feat: `abctl config init` command

### DIFF
--- a/internal/abctl/config.go
+++ b/internal/abctl/config.go
@@ -1,0 +1,9 @@
+package abctl
+
+// Config holds configuration extracted from Airbyte installations.
+// May be moved to a more specific package as the architecture evolves.
+type Config struct {
+	AirbyteAPIHost string // From AIRBYTE_API_HOST env var
+	AirbyteURL     string // From AIRBYTE_URL env var
+	AirbyteAuthURL string // From AB_AIRBYTE_AUTH_IDENTITY_PROVIDER_OIDC_ENDPOINTS_AUTHORIZATION_SERVER_ENDPOINT env var
+}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/airbytehq/abctl/internal/cmd/images"
+	initcmd "github.com/airbytehq/abctl/internal/cmd/init"
 	"github.com/airbytehq/abctl/internal/cmd/local"
 	"github.com/airbytehq/abctl/internal/cmd/version"
 	"github.com/airbytehq/abctl/internal/k8s"
@@ -20,6 +21,7 @@ func (v verbose) BeforeApply() error {
 }
 
 type Cmd struct {
+	Init    initcmd.Cmd `cmd:"" help:"Initialize abctl configuration from existing Airbyte installation."`
 	Local   local.Cmd   `cmd:"" help:"Manage the local Airbyte installation."`
 	Images  images.Cmd  `cmd:"" help:"Manage images used by Airbyte and abctl."`
 	Version version.Cmd `cmd:"" help:"Display version information."`

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"context"
 
+	"github.com/airbytehq/abctl/internal/cmd/config"
 	"github.com/airbytehq/abctl/internal/cmd/images"
-	initcmd "github.com/airbytehq/abctl/internal/cmd/init"
 	"github.com/airbytehq/abctl/internal/cmd/local"
 	"github.com/airbytehq/abctl/internal/cmd/version"
 	"github.com/airbytehq/abctl/internal/k8s"
@@ -21,7 +21,7 @@ func (v verbose) BeforeApply() error {
 }
 
 type Cmd struct {
-	Init    initcmd.Cmd `cmd:"" help:"Initialize abctl configuration from existing Airbyte installation."`
+	Config  config.Cmd  `cmd:"" help:"Manage abctl configuration."`
 	Local   local.Cmd   `cmd:"" help:"Manage the local Airbyte installation."`
 	Images  images.Cmd  `cmd:"" help:"Manage images used by Airbyte and abctl."`
 	Version version.Cmd `cmd:"" help:"Display version information."`

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -1,0 +1,6 @@
+package config
+
+// Cmd represents the config command group
+type Cmd struct {
+	Init InitCmd `cmd:"" help:"Initialize abctl configuration from existing Airbyte installation."`
+}

--- a/internal/cmd/init/init.go
+++ b/internal/cmd/init/init.go
@@ -1,0 +1,126 @@
+package init
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/airbytehq/abctl/internal/k8s"
+	"github.com/airbytehq/abctl/internal/service"
+	"github.com/pterm/pterm"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Cmd represents the init command
+type Cmd struct {
+	Namespace     string `flag:"" short:"n" help:"Target c.Namespace (default: current kubeconfig context)."`
+	Force         bool   `flag:"" help:"Overwrite existing abctl ConfigMap."`
+	FromConfigmap string `flag:"" help:"Source ConfigMap name (default: auto-detect via airbyte=templates label)."`
+}
+
+// Run executes the init command
+func (c *Cmd) Run(ctx context.Context, provider k8s.Provider) error {
+	pterm.Info.Println("Initializing abctl configuration...")
+
+	pterm.Info.Printf("Using c.Namespace: %s\n", c.Namespace)
+	pterm.Debug.Printf("Provider kubeconfig: %s\n", provider.Kubeconfig)
+	pterm.Debug.Printf("Provider context: %s\n", provider.Context)
+
+	// Create k8s client using standard kubeconfig resolution (KUBECONFIG env var or ~/.kube/config)
+	k8sClient, err := service.DefaultK8s("", "")
+	if err != nil {
+		return fmt.Errorf("failed to create k8s client: %w", err)
+	}
+
+	// Determine source ConfigMap name
+	sourceConfigMapName := c.FromConfigmap
+	if sourceConfigMapName == "" {
+		// Find ConfigMap with -airbyte-env suffix
+		sourceConfigMapName, err = findAirbyteEnvConfigMap(ctx, k8sClient, c.Namespace)
+		if err != nil {
+			return fmt.Errorf("failed to auto-detect Airbyte ConfigMap: %w", err)
+		}
+	}
+
+	pterm.Info.Printf("Reading from ConfigMap: %s\n", sourceConfigMapName)
+
+	// Read the source ConfigMap
+	pterm.Debug.Printf("Attempting to get ConfigMap: c.Namespace=%s, name=%s\n", c.Namespace, sourceConfigMapName)
+	sourceConfigMap, err := k8sClient.ConfigMapGet(ctx, c.Namespace, sourceConfigMapName)
+	if err != nil {
+		return fmt.Errorf("failed to read ConfigMap %s/%s: %w", c.Namespace, sourceConfigMapName, err)
+	}
+
+	pterm.Success.Printf("Found ConfigMap %s with %d keys\n", sourceConfigMapName, len(sourceConfigMap.Data))
+
+	// Extract key configuration values
+	config, err := k8s.AbctlConfigFromData(sourceConfigMap.Data)
+	if err != nil {
+		return fmt.Errorf("failed to extract configuration: %w", err)
+	}
+
+	pterm.Info.Printf("Extracted configuration:\n")
+	pterm.Info.Printf("  Airbyte API Host: %s\n", config.AirbyteAPIHost)
+	pterm.Info.Printf("  Airbyte URL: %s\n", config.AirbyteURL)
+
+	// Check if abctl ConfigMap already exists
+	const abctlConfigMapName = "abctl"
+	_, err = k8sClient.ConfigMapGet(ctx, c.Namespace, abctlConfigMapName)
+	if err == nil && !c.Force {
+		return fmt.Errorf("abctl ConfigMap already exists in c.Namespace %s, use --force to overwrite", c.Namespace)
+	}
+
+	// Create abctl ConfigMap
+	abctlConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      abctlConfigMapName,
+			Namespace: c.Namespace,
+			Annotations: map[string]string{
+				"abctl.airbyte.com/initialized-from": sourceConfigMapName,
+				"abctl.airbyte.com/initialized-at":   time.Now().Format(time.RFC3339),
+			},
+		},
+		Data: map[string]string{
+			"airbyteApiHost": config.AirbyteAPIHost,
+			"airbyteURL":     config.AirbyteURL,
+			"airbyteAuthURL": config.AirbyteAuthURL,
+		},
+	}
+
+	// Create or update the ConfigMap
+	if err = k8sClient.ConfigMapCreate(ctx, abctlConfigMap); err != nil {
+		// If creation failed and --force is set, try to update
+		if c.Force {
+			if updateErr := k8sClient.ConfigMapUpdate(ctx, abctlConfigMap); updateErr != nil {
+				return fmt.Errorf("failed to create or update abctl ConfigMap: %w", updateErr)
+			}
+			pterm.Success.Printf("Updated abctl ConfigMap in c.Namespace %s\n", c.Namespace)
+		} else {
+			return fmt.Errorf("failed to create abctl ConfigMap: %w", err)
+		}
+	} else {
+		pterm.Success.Printf("Created abctl ConfigMap in c.Namespace %s\n", c.Namespace)
+	}
+
+	pterm.Info.Println("Configuration initialization completed successfully")
+
+	return nil
+}
+
+// findAirbyteEnvConfigMap finds a ConfigMap whose name ends with "-airbyte-env" suffix
+func findAirbyteEnvConfigMap(ctx context.Context, k8sClient k8s.Client, namespace string) (string, error) {
+	configMaps, err := k8sClient.ConfigMapList(ctx, namespace)
+	if err != nil {
+		return "", fmt.Errorf("failed to list ConfigMaps: %w", err)
+	}
+
+	const suffix = "-airbyte-env"
+	for _, cm := range configMaps.Items {
+		if len(cm.Name) >= len(suffix) && cm.Name[len(cm.Name)-len(suffix):] == suffix {
+			return cm.Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("no ConfigMap with suffix %q found in namespace %s", suffix, namespace)
+}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -61,6 +61,15 @@ type Client interface {
 	SecretDeleteCollection(ctx context.Context, namespace, _type string) error
 	SecretGet(ctx context.Context, namespace, name string) (*corev1.Secret, error)
 
+	// ConfigMapGet retrieves a ConfigMap by name
+	ConfigMapGet(ctx context.Context, namespace, name string) (*corev1.ConfigMap, error)
+	// ConfigMapList lists ConfigMaps in a namespace
+	ConfigMapList(ctx context.Context, namespace string) (*corev1.ConfigMapList, error)
+	// ConfigMapCreate creates a new ConfigMap
+	ConfigMapCreate(ctx context.Context, configMap *corev1.ConfigMap) error
+	// ConfigMapUpdate updates an existing ConfigMap
+	ConfigMapUpdate(ctx context.Context, configMap *corev1.ConfigMap) error
+
 	ServiceGet(ctx context.Context, namespace, name string) (*corev1.Service, error)
 
 	StreamPodLogs(ctx context.Context, namespace string, podName string, since time.Time) (io.ReadCloser, error)
@@ -335,4 +344,25 @@ func (d *DefaultK8sClient) StreamPodLogs(ctx context.Context, namespace string, 
 
 func (d *DefaultK8sClient) PodList(ctx context.Context, namespace string) (*corev1.PodList, error) {
 	return d.ClientSet.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+}
+
+// ConfigMapGet retrieves a ConfigMap by name
+func (d *DefaultK8sClient) ConfigMapGet(ctx context.Context, namespace, name string) (*corev1.ConfigMap, error) {
+	return d.ClientSet.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+// ConfigMapCreate creates a new ConfigMap
+func (d *DefaultK8sClient) ConfigMapCreate(ctx context.Context, configMap *corev1.ConfigMap) error {
+	_, err := d.ClientSet.CoreV1().ConfigMaps(configMap.Namespace).Create(ctx, configMap, metav1.CreateOptions{})
+	return err
+}
+
+// ConfigMapUpdate updates an existing ConfigMap
+func (d *DefaultK8sClient) ConfigMapUpdate(ctx context.Context, configMap *corev1.ConfigMap) error {
+	_, err := d.ClientSet.CoreV1().ConfigMaps(configMap.Namespace).Update(ctx, configMap, metav1.UpdateOptions{})
+	return err
+}
+
+func (d *DefaultK8sClient) ConfigMapList(ctx context.Context, namespace string) (*corev1.ConfigMapList, error) {
+	return d.ClientSet.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{})
 }

--- a/internal/k8s/config.go
+++ b/internal/k8s/config.go
@@ -1,0 +1,55 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/airbytehq/abctl/internal/abctl"
+)
+
+// AbctlConfigFromData extracts abctl configuration from ConfigMap data
+func AbctlConfigFromData(data map[string]string) (*abctl.Config, error) {
+	config := &abctl.Config{}
+	
+	// Extract required values
+	config.AirbyteAPIHost = data["AIRBYTE_API_HOST"]
+	if config.AirbyteAPIHost == "" {
+		return nil, fmt.Errorf("required field AIRBYTE_API_HOST not found or empty")
+	}
+	
+	config.AirbyteURL = data["AIRBYTE_URL"]
+	if config.AirbyteURL == "" {
+		return nil, fmt.Errorf("required field AIRBYTE_URL not found or empty")
+	}
+	
+	// Extract auth endpoint if available
+	config.AirbyteAuthURL = data["AB_AIRBYTE_AUTH_IDENTITY_PROVIDER_OIDC_ENDPOINTS_AUTHORIZATION_SERVER_ENDPOINT"]
+	
+	return config, nil
+}
+
+// GetAbctlConfig gets the abctl configuration from k8s
+func GetAbctlConfig(ctx context.Context, client Client, namespace string) (*abctl.Config, error) {
+	configMap, err := client.ConfigMapGet(ctx, namespace, "abctl")
+	if err != nil {
+		return nil, fmt.Errorf("failed to load abctl config: %w (hint: run 'abctl init' first)", err)
+	}
+
+	apiHost := configMap.Data["airbyteApiHost"]
+	if apiHost == "" {
+		return nil, fmt.Errorf("airbyteApiHost not found in abctl config")
+	}
+
+	airbyteURL := configMap.Data["airbyteURL"]
+	if airbyteURL == "" {
+		return nil, fmt.Errorf("airbyteURL not found in abctl config")
+	}
+
+	authURL := configMap.Data["airbyteAuthURL"]
+
+	return &abctl.Config{
+		AirbyteAPIHost: apiHost,
+		AirbyteURL:     airbyteURL,
+		AirbyteAuthURL: authURL,
+	}, nil
+}

--- a/internal/k8s/config_test.go
+++ b/internal/k8s/config_test.go
@@ -1,0 +1,112 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/airbytehq/abctl/internal/abctl"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAbctlConfigFromData(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    map[string]string
+		want    *abctl.Config
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "successful extraction",
+			data: map[string]string{
+				"AIRBYTE_API_HOST": "http://localhost:8001/api/public",
+				"AIRBYTE_URL":      "https://local.airbyte.dev",
+				"AB_AIRBYTE_AUTH_IDENTITY_PROVIDER_OIDC_ENDPOINTS_AUTHORIZATION_SERVER_ENDPOINT": "https://keycloak.internal.airbyte.dev/auth/realms/airbyte",
+			},
+			want: &abctl.Config{
+				AirbyteAPIHost: "http://localhost:8001/api/public",
+				AirbyteURL:     "https://local.airbyte.dev",
+				AirbyteAuthURL: "https://keycloak.internal.airbyte.dev/auth/realms/airbyte",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing AIRBYTE_API_HOST",
+			data: map[string]string{
+				"AIRBYTE_URL":    "https://local.airbyte.dev",
+				"SOME_OTHER_VAR": "value",
+			},
+			want:    nil,
+			wantErr: true,
+			errMsg:  "required field AIRBYTE_API_HOST not found or empty",
+		},
+		{
+			name: "missing AIRBYTE_URL",
+			data: map[string]string{
+				"AIRBYTE_API_HOST": "http://localhost:8001/api/public",
+				"SOME_OTHER_VAR":   "value",
+			},
+			want:    nil,
+			wantErr: true,
+			errMsg:  "required field AIRBYTE_URL not found or empty",
+		},
+		{
+			name: "empty AIRBYTE_API_HOST",
+			data: map[string]string{
+				"AIRBYTE_API_HOST": "",
+				"AIRBYTE_URL":      "https://local.airbyte.dev",
+			},
+			want:    nil,
+			wantErr: true,
+			errMsg:  "required field AIRBYTE_API_HOST not found or empty",
+		},
+		{
+			name: "empty AIRBYTE_URL",
+			data: map[string]string{
+				"AIRBYTE_API_HOST": "http://localhost:8001/api/public",
+				"AIRBYTE_URL":      "",
+			},
+			want:    nil,
+			wantErr: true,
+			errMsg:  "required field AIRBYTE_URL not found or empty",
+		},
+		{
+			name: "successful extraction without auth URL",
+			data: map[string]string{
+				"AIRBYTE_API_HOST": "http://localhost:8001/api/public",
+				"AIRBYTE_URL":      "https://local.airbyte.dev",
+			},
+			want: &abctl.Config{
+				AirbyteAPIHost: "http://localhost:8001/api/public",
+				AirbyteURL:     "https://local.airbyte.dev",
+				AirbyteAuthURL: "", // Should be empty when not provided
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := AbctlConfigFromData(tt.data)
+			
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("AbctlConfigFromData() error = nil, wantErr %v", tt.wantErr)
+					return
+				}
+				if tt.errMsg != "" && err.Error() != tt.errMsg {
+					t.Errorf("AbctlConfigFromData() error = %v, want %v", err.Error(), tt.errMsg)
+				}
+				return
+			}
+			
+			if err != nil {
+				t.Errorf("AbctlConfigFromData() unexpected error = %v", err)
+				return
+			}
+			
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("AbctlConfigFromData() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/k8s/k8stest/k8stest.go
+++ b/internal/k8s/k8stest/k8stest.go
@@ -38,6 +38,10 @@ type MockClient struct {
 	FnLogsGet                     func(ctx context.Context, namespace string, name string) (string, error)
 	FnStreamPodLogs               func(ctx context.Context, namespace, podName string, since time.Time) (io.ReadCloser, error)
 	FnPodList                     func(ctx context.Context, namespace string) (*corev1.PodList, error)
+	FnConfigMapGet                func(ctx context.Context, namespace, name string) (*corev1.ConfigMap, error)
+	FnConfigMapList               func(ctx context.Context, namespace string) (*corev1.ConfigMapList, error)
+	FnConfigMapCreate             func(ctx context.Context, configMap *corev1.ConfigMap) error
+	FnConfigMapUpdate             func(ctx context.Context, configMap *corev1.ConfigMap) error
 }
 
 func (m *MockClient) DeploymentList(ctx context.Context, namespace string) (*v1.DeploymentList, error) {
@@ -99,12 +103,14 @@ func (m *MockClient) PersistentVolumeCreate(ctx context.Context, namespace, name
 	}
 	return nil
 }
+
 func (m *MockClient) PersistentVolumeExists(ctx context.Context, namespace, name string) bool {
 	if m.FnPersistentVolumeExists != nil {
 		return m.FnPersistentVolumeExists(ctx, namespace, name)
 	}
 	return true
 }
+
 func (m *MockClient) PersistentVolumeDelete(ctx context.Context, namespace, name string) error {
 	if m.FnPersistentVolumeDelete != nil {
 		return m.FnPersistentVolumeDelete(ctx, namespace, name)
@@ -118,12 +124,14 @@ func (m *MockClient) PersistentVolumeClaimCreate(ctx context.Context, namespace,
 	}
 	return nil
 }
+
 func (m *MockClient) PersistentVolumeClaimExists(ctx context.Context, namespace, name, volumeName string) bool {
 	if m.FnPersistentVolumeClaimExists != nil {
 		return m.FnPersistentVolumeClaimExists(ctx, namespace, name, volumeName)
 	}
 	return true
 }
+
 func (m *MockClient) PersistentVolumeClaimDelete(ctx context.Context, namespace, name, volumeName string) error {
 	if m.FnPersistentVolumeClaimDelete != nil {
 		return m.FnPersistentVolumeClaimDelete(ctx, namespace, name, volumeName)
@@ -192,4 +200,32 @@ func (m *MockClient) PodList(ctx context.Context, namespace string) (*corev1.Pod
 		return &corev1.PodList{}, nil
 	}
 	return m.FnPodList(ctx, namespace)
+}
+
+func (m *MockClient) ConfigMapGet(ctx context.Context, namespace, name string) (*corev1.ConfigMap, error) {
+	if m.FnConfigMapGet == nil {
+		return &corev1.ConfigMap{}, nil
+	}
+	return m.FnConfigMapGet(ctx, namespace, name)
+}
+
+func (m *MockClient) ConfigMapList(ctx context.Context, namespace string) (*corev1.ConfigMapList, error) {
+	if m.FnConfigMapList == nil {
+		return &corev1.ConfigMapList{}, nil
+	}
+	return m.FnConfigMapList(ctx, namespace)
+}
+
+func (m *MockClient) ConfigMapCreate(ctx context.Context, configMap *corev1.ConfigMap) error {
+	if m.FnConfigMapCreate == nil {
+		return nil
+	}
+	return m.FnConfigMapCreate(ctx, configMap)
+}
+
+func (m *MockClient) ConfigMapUpdate(ctx context.Context, configMap *corev1.ConfigMap) error {
+	if m.FnConfigMapUpdate == nil {
+		return nil
+	}
+	return m.FnConfigMapUpdate(ctx, configMap)
 }

--- a/internal/k8s/namespace.go
+++ b/internal/k8s/namespace.go
@@ -1,0 +1,39 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// GetCurrentNamespace returns the namespace from the current kubeconfig context.
+// If no namespace is set in the context, it returns "default".
+func GetCurrentNamespace() (string, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	config := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules,
+		&clientcmd.ConfigOverrides{},
+	)
+	
+	namespace, _, err := config.Namespace()
+	if err != nil {
+		return "", err
+	}
+	
+	if namespace == "" {
+		return "default", nil
+	}
+	
+	return namespace, nil
+}
+
+// IsAbctlInitialized checks if abctl is initialized in the given namespace.
+// Returns an error with helpful message if not initialized.
+func IsAbctlInitialized(ctx context.Context, client Client, namespace string) error {
+	_, err := client.ConfigMapGet(ctx, namespace, "abctl")
+	if err != nil {
+		return fmt.Errorf("abctl not initialized: %w (hint: run 'abctl init' first)", err)
+	}
+	return nil
+}

--- a/internal/service/manager.go
+++ b/internal/service/manager.go
@@ -187,8 +187,18 @@ func NewManager(provider k8s.Provider, opts ...Option) (*Manager, error) {
 // DefaultK8s returns the default k8s client
 func DefaultK8s(kubecfg, kubectx string) (k8s.Client, error) {
 	rest.SetDefaultWarningHandler(k8s.Logger{})
+	
+	// Use default loading rules if kubecfg is empty
+	var loadingRules *clientcmd.ClientConfigLoadingRules
+	if kubecfg == "" {
+		// This will use KUBECONFIG env var or default ~/.kube/config
+		loadingRules = clientcmd.NewDefaultClientConfigLoadingRules()
+	} else {
+		loadingRules = &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubecfg}
+	}
+	
 	k8sCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubecfg},
+		loadingRules,
 		&clientcmd.ConfigOverrides{CurrentContext: kubectx},
 	)
 

--- a/internal/service/manager_test.go
+++ b/internal/service/manager_test.go
@@ -1,0 +1,97 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultK8s_KubeconfigHandling(t *testing.T) {
+	// Save original KUBECONFIG env var
+	originalKubeconfig := os.Getenv("KUBECONFIG")
+	defer func() {
+		os.Setenv("KUBECONFIG", originalKubeconfig)
+	}()
+
+	tests := []struct {
+		name       string
+		kubecfg    string
+		kubectx    string
+		setupEnv   func()
+		wantErr    bool
+		errContains string
+	}{
+		{
+			name:    "explicit kubeconfig path",
+			kubecfg: "/tmp/test-kubeconfig",
+			kubectx: "",
+			setupEnv: func() {
+				os.Unsetenv("KUBECONFIG")
+			},
+			wantErr:     true,
+			errContains: "no such file or directory",
+		},
+		{
+			name:    "empty kubeconfig uses default resolution",
+			kubecfg: "",
+			kubectx: "",
+			setupEnv: func() {
+				// Test with KUBECONFIG env var set
+				tmpDir := t.TempDir()
+				testConfig := filepath.Join(tmpDir, "test.config")
+				os.Setenv("KUBECONFIG", testConfig)
+			},
+			wantErr:     true,
+			errContains: "invalid configuration",
+		},
+		{
+			name:    "empty kubeconfig with invalid KUBECONFIG env",
+			kubecfg: "",
+			kubectx: "",
+			setupEnv: func() {
+				// Set KUBECONFIG to a non-existent file
+				os.Setenv("KUBECONFIG", "/tmp/nonexistent-kubeconfig-for-test")
+			},
+			wantErr:     true,
+			errContains: "invalid configuration",
+		},
+		{
+			name:    "explicit context override with non-existent context",
+			kubecfg: "",
+			kubectx: "custom-context",
+			setupEnv: func() {
+				// Set KUBECONFIG to a non-existent file
+				os.Setenv("KUBECONFIG", "/tmp/nonexistent-kubeconfig-for-test")
+			},
+			wantErr:     true,
+			errContains: "context \"custom-context\" does not exist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupEnv()
+			
+			_, err := DefaultK8s(tt.kubecfg, tt.kubectx)
+			
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("DefaultK8s() error = nil, wantErr %v", tt.wantErr)
+					return
+				}
+				if tt.errContains != "" && !contains(err.Error(), tt.errContains) {
+					t.Errorf("DefaultK8s() error = %v, want error containing %v", err.Error(), tt.errContains)
+				}
+				return
+			}
+			
+			if err != nil {
+				t.Errorf("DefaultK8s() unexpected error = %v", err)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && s[0:len(substr)] == substr || len(s) > len(substr) && contains(s[1:], substr)
+}


### PR DESCRIPTION
# Summary

Works towards Airbyte dataplane installation and management. Adds `abctl config init` command to bootstrap abctl configuration from existing Airbyte Kubernetes deployments. Auto-detects Airbyte ConfigMaps ending with `-airbyte-env` suffix and extracts API endpoints and auth settings. It is envisioned that Abctl installation will automatically create the Abctl configmap during installation. Though I have added ample test coverage, and put some thought into this PR, there will might be some gaps. I'm hoping I can address these issues in future PRs before cutting a new release.

# What's New

`abctl config init` Command

- Auto-detects source ConfigMap using -airbyte-env suffix pattern
- Extracts AIRBYTE_API_HOST, AIRBYTE_URL, and auth endpoints
- Creates abctl ConfigMap with the extracted config
- --from-configmap to specify source manually
- --force to overwrite existing config

# Better Kubeconfig Handling

  - DefaultK8s() now respects KUBECONFIG env var when no explicit path given
  - Falls back to ~/.kube/config as expected
  - Backward compatible

# K8s Client Extensions

Added ConfigMap operations: Get, List, Create, Update

# Config Utilities

- AbctlConfigFromData() - extracts config from ConfigMap data
- GetAbctlConfig() - fetches abctl config from k8s

#  Usage

## Auto-detect and init
```
abctl config init -n airbyte
```
## Manual source
```
abctl config init -n airbyte --from-configmap my-airbyte-env
```
  ## Force overwrite
```
  abctl config init -n airbyte --force
```

#  Note

The bernielomax/feat/auth-login-logout branch adds GetCurrentNamespace() for better namespace detection from kubeconfig context - pairs nicely with this init command. It also introduces the `auth login` `auth logout` command which builds upon this PR. 

# Tests
Full test coverage for ConfigMap operations, config extraction, and kubeconfig resolution.