### PR TITLE
fix: include Helm hook resources in images manifest

### DIFF
--- a/internal/helm/images.go
+++ b/internal/helm/images.go
@@ -41,7 +41,13 @@ func FindImagesFromChart(client goHelm.Client, valuesYaml, chartName, chartVersi
 		return nil, err
 	}
 
-	images := findAllImages(rel.Manifest)
+	// Combine main manifest with hook manifests to include resources like bootloader
+	fullManifest := rel.Manifest
+	for _, hook := range rel.Hooks {
+		fullManifest += "\n---\n" + hook.Manifest
+	}
+
+	images := findAllImages(fullManifest)
 	return images, nil
 }
 


### PR DESCRIPTION
The images manifest command was missing images from Helm hook resources like the bootloader Pod. Hook resources are returned separately in rel.Hooks rather than rel.Manifest, so we need to combine both to capture all container images.

Also added test coverage for hook resources to prevent regression.