### PR TITLE
feat: add global.airbyteUrl Helm value for Airbyte 2.0.0+

### DIFF
--- a/internal/cmd/local/install.go
+++ b/internal/cmd/local/install.go
@@ -209,6 +209,7 @@ func (i *InstallCmd) installOpts(ctx context.Context, user string) (*service.Ins
 		DisableAuth:     i.DisableAuth,
 		LocalStorage:    !supportMinio,
 		EnablePsql17:    enablePsql17,
+		Port:            i.Port,
 	}
 
 	if opts.DockerAuth() {

--- a/internal/cmd/local/local_test.go
+++ b/internal/cmd/local/local_test.go
@@ -118,7 +118,7 @@ func TestValues_FileDoesntExist(t *testing.T) {
 }
 
 func TestValues_BadYaml(t *testing.T) {
-	cmd := InstallCmd{Values: "./testdata/invalid.values.yaml"}
+	cmd := InstallCmd{Values: "./testdata/invalid.values.yaml", Port: 8000}
 	// Does not need actual clients for tests.
 	testFactory := func(kubeConfig, kubeContext string) (k8s.Client, goHelm.Client, error) {
 		return nil, nil, nil
@@ -134,7 +134,7 @@ func TestValues_BadYaml(t *testing.T) {
 }
 
 func TestInvalidHostFlag_IpAddr(t *testing.T) {
-	cmd := InstallCmd{Host: []string{"ok", "1.2.3.4"}}
+	cmd := InstallCmd{Host: []string{"ok", "1.2.3.4"}, Port: 8000}
 	// Does not need actual clients for tests.
 	testFactory := func(kubeConfig, kubeContext string) (k8s.Client, goHelm.Client, error) {
 		return nil, nil, nil
@@ -146,7 +146,7 @@ func TestInvalidHostFlag_IpAddr(t *testing.T) {
 }
 
 func TestInvalidHostFlag_IpAddrWithPort(t *testing.T) {
-	cmd := InstallCmd{Host: []string{"ok", "1.2.3.4:8000"}}
+	cmd := InstallCmd{Host: []string{"ok", "1.2.3.4:8000"}, Port: 8000}
 	// Does not need actual clients for tests.
 	testFactory := func(kubeConfig, kubeContext string) (k8s.Client, goHelm.Client, error) {
 		return nil, nil, nil
@@ -162,6 +162,7 @@ func TestInstallOpts(t *testing.T) {
 	cmd := InstallCmd{
 		// Don't let the code dynamically resolve the latest chart version.
 		Chart: "/test/path/to/chart",
+		Port:  8000,
 	}
 	expect := &service.InstallOpts{
 		HelmValuesYaml:  string(b),

--- a/internal/helm/airbyte_values.go
+++ b/internal/helm/airbyte_values.go
@@ -117,7 +117,12 @@ func buildAirbyteValuesV2(ctx context.Context, opts ValuesOpts) (string, error) 
 	span := trace.SpanFromContext(ctx)
 
 	vals := []string{
+		// WEBAPP_URL is required for backward compatibility with v2 Helm charts prior to Airbyte 2.0.0.
+		// Starting with Airbyte 2.0.0, the platform uses AIRBYTE_URL instead (set via global.airbyteUrl).
+		// Both are set here to support all v2 chart versions. WEBAPP_URL can be removed once all
+		// supported chart versions are >= 2.0.0.
 		"server.env_vars.WEBAPP_URL=http://airbyte-abctl-airbyte-server-svc:80",
+		"global.airbyteUrl=http://localhost:8000",
 		"global.env_vars.AIRBYTE_INSTALLATION_ID=" + opts.TelemetryUser,
 		"global.jobs.resources.limits.cpu=3",
 		"global.jobs.resources.limits.memory=4Gi",

--- a/internal/helm/airbyte_values.go
+++ b/internal/helm/airbyte_values.go
@@ -19,6 +19,7 @@ type ValuesOpts struct {
 	DisableAuth     bool
 	LocalStorage    bool
 	EnablePsql17    bool
+	Port            int
 }
 
 const (
@@ -116,13 +117,21 @@ func buildAirbyteValuesV1(ctx context.Context, opts ValuesOpts) (string, error) 
 func buildAirbyteValuesV2(ctx context.Context, opts ValuesOpts) (string, error) {
 	span := trace.SpanFromContext(ctx)
 
+	// Validate port is in valid range
+	if opts.Port <= 0 || opts.Port > 65535 {
+		return "", fmt.Errorf("invalid port %d: must be between 1 and 65535", opts.Port)
+	}
+
+	airbyteURL := fmt.Sprintf("http://localhost:%d", opts.Port)
+
 	vals := []string{
 		// WEBAPP_URL is required for backward compatibility with v2 Helm charts prior to Airbyte 2.0.0.
 		// Starting with Airbyte 2.0.0, the platform uses AIRBYTE_URL instead (set via global.airbyteUrl).
 		// Both are set here to support all v2 chart versions. WEBAPP_URL can be removed once all
 		// supported chart versions are >= 2.0.0.
-		"server.env_vars.WEBAPP_URL=http://airbyte-abctl-airbyte-server-svc:80",
-		"global.airbyteUrl=http://localhost:8000",
+		// Port is omitted to use HTTP default (80), allowing users to override the service port via Helm values.
+		"server.env_vars.WEBAPP_URL=http://airbyte-abctl-airbyte-server-svc",
+		"global.airbyteUrl=" + airbyteURL,
 		"global.env_vars.AIRBYTE_INSTALLATION_ID=" + opts.TelemetryUser,
 		"global.jobs.resources.limits.cpu=3",
 		"global.jobs.resources.limits.memory=4Gi",

--- a/internal/helm/airbyte_values_test.go
+++ b/internal/helm/airbyte_values_test.go
@@ -212,8 +212,8 @@ global:
 `,
 		},
 		{
-			name:         "v2: default options",
-			opts:         ValuesOpts{TelemetryUser: "test-user"},
+			name:         "v2: minimal options",
+			opts:         ValuesOpts{TelemetryUser: "test-user", Port: 8000},
 			chartVersion: "2.0.0",
 			want: `airbyte-bootloader:
     env_vars:
@@ -231,12 +231,12 @@ global:
                 memory: 4Gi
 server:
     env_vars:
-        WEBAPP_URL: http://airbyte-abctl-airbyte-server-svc:80
+        WEBAPP_URL: http://airbyte-abctl-airbyte-server-svc
 `,
 		},
 		{
 			name:         "v2: all options enabled",
-			opts:         ValuesOpts{TelemetryUser: "test-user", LocalStorage: true, EnablePsql17: true, LowResourceMode: true, InsecureCookies: true, ImagePullSecret: "mysecret", DisableAuth: false},
+			opts:         ValuesOpts{TelemetryUser: "test-user", LocalStorage: true, EnablePsql17: true, LowResourceMode: true, InsecureCookies: true, ImagePullSecret: "mysecret", DisableAuth: false, Port: 8000},
 			chartVersion: "2.0.0",
 			want: `airbyte-bootloader:
     env_vars:
@@ -269,7 +269,7 @@ postgresql:
 server:
     env_vars:
         JOB_RESOURCE_VARIANT_OVERRIDE: lowresource
-        WEBAPP_URL: http://airbyte-abctl-airbyte-server-svc:80
+        WEBAPP_URL: http://airbyte-abctl-airbyte-server-svc
 workloadLauncher:
     env_vars:
         CHECK_JOB_MAIN_CONTAINER_CPU_REQUEST: "0"
@@ -321,19 +321,30 @@ global:
 `,
 		},
 		{
-			name: "v2: invalid values file returns error",
+			name: "v2: invalid values file",
 			opts: ValuesOpts{
 				TelemetryUser: "test-user",
 				ValuesFile:    filepath.Join(testdataDir, "invalid.values.yaml"),
+				Port:          8000,
 			},
 			chartVersion: "2.0.0",
 			wantErr:      true,
 		},
 		{
-			name: "v2: values file not found returns error",
+			name: "v2: values file not found",
 			opts: ValuesOpts{
 				TelemetryUser: "test-user",
 				ValuesFile:    filepath.Join(testdataDir, "nonexistent.values.yaml"),
+				Port:          8000,
+			},
+			chartVersion: "2.0.0",
+			wantErr:      true,
+		},
+		{
+			name: "v2: invalid port",
+			opts: ValuesOpts{
+				TelemetryUser: "test-user",
+				Port:          0,
 			},
 			chartVersion: "2.0.0",
 			wantErr:      true,

--- a/internal/helm/airbyte_values_test.go
+++ b/internal/helm/airbyte_values_test.go
@@ -219,6 +219,7 @@ global:
     env_vars:
         PLATFORM_LOG_FORMAT: json
 global:
+    airbyteUrl: http://localhost:8000
     auth:
         enabled: true
     env_vars:
@@ -243,6 +244,7 @@ server:
 connectorBuilderServer:
     enabled: false
 global:
+    airbyteUrl: http://localhost:8000
     auth:
         security:
             cookieSecureSetting: '"false"'


### PR DESCRIPTION
Adds `global.airbyteUrl=http://localhost:8000` to v2 Helm chart values to support Airbyte platform 2.0.0+, which replaced `WEBAPP_URL` with `AIRBYTE_URL` environment variable.

Both `WEBAPP_URL` and `airbyteUrl` are set for backward compatibility. `WEBAPP_URL` can be removed once minimum supported Airbyte version is `>= 2.0.0`.