### PR TITLE
fix: ingress for airbyte 1.8+ must target server instead of webapp

### DIFF
--- a/internal/helm/chart.go
+++ b/internal/helm/chart.go
@@ -40,13 +40,23 @@ func NewChartResolverWithURLs(client goHelm.Client, v1URL, v2URL string) *ChartR
 
 // ChartIsV2Plus returns true if the chart version is v2.0.0 or higher
 func ChartIsV2Plus(v string) bool {
+	return ChartEqualsOrHigherVersion(v, "v2.0.0")
+}
+
+// ChartIsV1_8Plus returns true if the chart version is v1.8.0 or higher
+func ChartIsV1_8Plus(v string) bool {
+	return ChartEqualsOrHigherVersion(v, "v1.8.0")
+}
+
+// ChartEqualsOrHigherVersion returns true if the chart version is equals or higher than threshold
+func ChartEqualsOrHigherVersion(v string, threshold string) bool {
 	if v == "" {
 		return false
 	}
 	if v[0] != 'v' {
 		v = "v" + v
 	}
-	return semver.Compare(v, "v2.0.0") >= 0
+	return semver.Compare(v, threshold) >= 0
 }
 
 // ResolveChartReference resolves an Airbyte chart reference to its full URL/path and version.

--- a/internal/helm/chart.go
+++ b/internal/helm/chart.go
@@ -43,8 +43,8 @@ func ChartIsV2Plus(v string) bool {
 	return ChartEqualsOrHigherVersion(v, "v2.0.0")
 }
 
-// ChartIsV1_8Plus returns true if the chart version is v1.8.0 or higher
-func ChartIsV1_8Plus(v string) bool {
+// ChartIsV1Dot8Plus returns true if the chart version is v1.8.0 or higher
+func ChartIsV1Dot8Plus(v string) bool {
 	return ChartEqualsOrHigherVersion(v, "v1.8.0")
 }
 

--- a/internal/helm/chart_test.go
+++ b/internal/helm/chart_test.go
@@ -65,7 +65,7 @@ func TestChartIsV2Plus(t *testing.T) {
 	}
 }
 
-func TestChartIsV1_8Plus(t *testing.T) {
+func TestChartIsV1Dot8Plus(t *testing.T) {
 	tests := []struct {
 		name string
 		ver  string
@@ -130,7 +130,7 @@ func TestChartIsV1_8Plus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ChartIsV1_8Plus(tt.ver)
+			got := ChartIsV1Dot8Plus(tt.ver)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/helm/chart_test.go
+++ b/internal/helm/chart_test.go
@@ -65,6 +65,77 @@ func TestChartIsV2Plus(t *testing.T) {
 	}
 }
 
+func TestChartIsV1_8Plus(t *testing.T) {
+	tests := []struct {
+		name string
+		ver  string
+		want bool
+	}{
+		{
+			name: "empty version",
+			ver:  "",
+			want: false,
+		},
+		{
+			name: "v1 version",
+			ver:  "1.0.0",
+			want: false,
+		},
+		{
+			name: "v1 with v prefix",
+			ver:  "v1.0.0",
+			want: false,
+		},
+		{
+			name: "v1.8 version",
+			ver:  "1.8.0",
+			want: true,
+		},
+		{
+			name: "v1.8 with v prefix",
+			ver:  "v1.8.0",
+			want: true,
+		},
+		{
+			name: "v1.8.5 version",
+			ver:  "1.8.5",
+			want: true,
+		},
+		{
+			name: "v1.8.5 with v prefix",
+			ver:  "v1.8.5",
+			want: true,
+		},
+		{
+			name: "v2 version",
+			ver:  "2.0.0",
+			want: true,
+		},
+		{
+			name: "v2 with v prefix",
+			ver:  "v2.0.0",
+			want: true,
+		},
+		{
+			name: "v2 pre-release",
+			ver:  "v2.0.0-alpha.1",
+			want: true,
+		},
+		{
+			name: "v3 version",
+			ver:  "3.0.0",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ChartIsV1_8Plus(tt.ver)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestResolveChartReference(t *testing.T) {
 	t.Parallel()
 	ctrl := gomock.NewController(t)

--- a/internal/k8s/ingress.go
+++ b/internal/k8s/ingress.go
@@ -51,8 +51,8 @@ func Ingress(chartVersion string, hosts []string) *networkingv1.Ingress {
 // ingressRule creates a rule for the host with proper API routing.
 func ingressRules(chartVersion string, host string) networkingv1.IngressRule {
 	rules := ingressRulesForV1()
-	if helm.ChartIsV2Plus(chartVersion) {
-		rules = ingressRulesForV2()
+	if helm.ChartIsV1_8Plus(chartVersion) {
+		rules = ingressRulesForV1_8Plus()
 	}
 
 	return networkingv1.IngressRule{
@@ -98,7 +98,7 @@ func ingressRulesForV1() networkingv1.IngressRuleValue {
 	}
 }
 
-func ingressRulesForV2() networkingv1.IngressRuleValue {
+func ingressRulesForV1_8Plus() networkingv1.IngressRuleValue {
 	var pathType = networkingv1.PathType("Prefix")
 
 	return networkingv1.IngressRuleValue{

--- a/internal/k8s/ingress.go
+++ b/internal/k8s/ingress.go
@@ -51,8 +51,8 @@ func Ingress(chartVersion string, hosts []string) *networkingv1.Ingress {
 // ingressRule creates a rule for the host with proper API routing.
 func ingressRules(chartVersion string, host string) networkingv1.IngressRule {
 	rules := ingressRulesForV1()
-	if helm.ChartIsV1_8Plus(chartVersion) {
-		rules = ingressRulesForV1_8Plus()
+	if helm.ChartIsV1Dot8Plus(chartVersion) {
+		rules = ingressRulesForV1Dot8Plus()
 	}
 
 	return networkingv1.IngressRule{
@@ -98,7 +98,7 @@ func ingressRulesForV1() networkingv1.IngressRuleValue {
 	}
 }
 
-func ingressRulesForV1_8Plus() networkingv1.IngressRuleValue {
+func ingressRulesForV1Dot8Plus() networkingv1.IngressRuleValue {
 	var pathType = networkingv1.PathType("Prefix")
 
 	return networkingv1.IngressRuleValue{

--- a/internal/k8s/ingress_test.go
+++ b/internal/k8s/ingress_test.go
@@ -117,9 +117,14 @@ func TestIngressRouting(t *testing.T) {
 		wantService  string
 	}{
 		{
-			name:         "v1 routes to webapp",
-			chartVersion: "1.9.9",
+			name:         "v1.7 routes to webapp",
+			chartVersion: "1.7.1",
 			wantService:  "airbyte-abctl-airbyte-webapp-svc",
+		},
+		{
+			name:         "v1.9 routes to server",
+			chartVersion: "1.9.9",
+			wantService:  "airbyte-abctl-airbyte-server-svc",
 		},
 		{
 			name:         "v2 routes to server",


### PR DESCRIPTION
Fix https://github.com/airbytehq/airbyte/issues/65539

As webapp is already merged into server starting from airbyte 1.8 the ingress must be created accordingly