### PR TITLE
feat: untracked errors

### DIFF
--- a/internal/abctl/error.go
+++ b/internal/abctl/error.go
@@ -1,6 +1,26 @@
 package abctl
 
 var _ error = (*Error)(nil)
+var _ error = (*UntrackedError)(nil)
+
+// UntrackedError wraps errors caused by the user's environment (permissions,
+// disk space, docker not running, etc.) that should be displayed to the user
+// but not sent to error tracking since they are outside abctl's control.
+type UntrackedError struct {
+	err error
+}
+
+func (e UntrackedError) Error() string {
+	return e.err.Error()
+}
+
+func (e UntrackedError) Unwrap() error {
+	return e.err
+}
+
+func NewUntrackedError(err error) *UntrackedError {
+	return &UntrackedError{err: err}
+}
 
 // Error adds a user-friendly help message to specific errors.
 type Error struct {

--- a/internal/cmd/local/check.go
+++ b/internal/cmd/local/check.go
@@ -35,14 +35,18 @@ func dockerInstalled(ctx context.Context, telClient telemetry.Client) (docker.Ve
 	if dockerClient == nil {
 		if dockerClient, err = docker.New(ctx); err != nil {
 			pterm.Error.Println("Unable to create Docker client")
-			return docker.Version{}, fmt.Errorf("%w: unable to create client: %w", abctl.ErrDocker, err)
+			return docker.Version{}, abctl.NewUntrackedError(
+				fmt.Errorf("%w: unable to create client: %w", abctl.ErrDocker, err),
+			)
 		}
 	}
 
 	version, err := dockerClient.Version(ctx)
 	if err != nil {
 		pterm.Error.Println("Unable to communicate with the Docker daemon")
-		return docker.Version{}, fmt.Errorf("%w: %w", abctl.ErrDocker, err)
+		return docker.Version{}, abctl.NewUntrackedError(
+			fmt.Errorf("%w: %w", abctl.ErrDocker, err),
+		)
 	}
 
 	span.SetAttributes(
@@ -94,10 +98,14 @@ func portAvailable(ctx context.Context, port int) error {
 	lc := &net.ListenConfig{}
 	listener, err := lc.Listen(ctx, "tcp", fmt.Sprintf("localhost:%d", port))
 	if isErrorAddressAlreadyInUse(err) {
-		return fmt.Errorf("%w: port %d is already in use", abctl.ErrPort, port)
+		return abctl.NewUntrackedError(
+			fmt.Errorf("%w: port %d is already in use", abctl.ErrPort, port),
+		)
 	}
 	if err != nil {
-		return fmt.Errorf("%w: unable to determine if port '%d' is available: %w", abctl.ErrPort, port, err)
+		return abctl.NewUntrackedError(
+			fmt.Errorf("%w: unable to determine if port '%d' is available: %w", abctl.ErrPort, port, err),
+		)
 	}
 	// if we're able to bind to the port (and then release it), it should be available
 	defer func() {
@@ -193,10 +201,10 @@ func (e InvalidPortError) Error() string {
 
 func validateHostFlag(host string) error {
 	if ip := net.ParseIP(host); ip != nil {
-		return abctl.ErrIpAddressForHostFlag
+		return abctl.NewUntrackedError(abctl.ErrIpAddressForHostFlag)
 	}
 	if !regexp.MustCompile(`^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)*$`).MatchString(host) {
-		return abctl.ErrInvalidHostFlag
+		return abctl.NewUntrackedError(abctl.ErrInvalidHostFlag)
 	}
 	return nil
 }

--- a/internal/cmd/local/local.go
+++ b/internal/cmd/local/local.go
@@ -27,7 +27,9 @@ func (c *Cmd) BeforeApply() error {
 	}
 
 	if err := checkAirbyteDir(); err != nil {
-		return fmt.Errorf("%w: %w", abctl.ErrAirbyteDir, err)
+		return abctl.NewUntrackedError(
+			fmt.Errorf("%w: %w", abctl.ErrAirbyteDir, err),
+		)
 	}
 
 	return nil

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -148,7 +148,9 @@ func newWithOptions(ctx context.Context, newPing newPing, goos string) (*Docker,
 		}
 	}
 
-	return nil, fmt.Errorf("%w: unable to create docker client", abctl.ErrDocker)
+	return nil, abctl.NewUntrackedError(
+		fmt.Errorf("%w: unable to create docker client", abctl.ErrDocker),
+	)
 }
 
 // createAndPing attempts to create a docker client and ping it to ensure we can communicate

--- a/internal/service/manager.go
+++ b/internal/service/manager.go
@@ -241,7 +241,7 @@ func EnablePsql17() (bool, error) {
 
 	pgVersion, err := pgData.Version()
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return false, fmt.Errorf("failed to determine if any previous psql version exists: %w", err)
+		return false, abctl.NewUntrackedError(fmt.Errorf("failed to determine if any previous psql version exists: %w", err))
 	}
 
 	if pgVersion == "" || pgVersion == "17" {

--- a/main.go
+++ b/main.go
@@ -79,7 +79,11 @@ func handleErr(ctx context.Context, err error) int {
 		return 0
 	}
 
-	trace.CaptureError(ctx, err)
+	// Only send to error tracking if not an untracked error
+	var untrackedErr *abctl.UntrackedError
+	if !errors.As(err, &untrackedErr) {
+		trace.CaptureError(ctx, err)
+	}
 
 	pterm.Error.Println(err)
 


### PR DESCRIPTION
## Summary                                                                                                                                                      
                                                                                                                                                             
- Introduces `UntrackedError` type for errors outside abctl's control (permissions, docker not running, port in use, etc.)                                     
- These errors display to users but don't get sent to Sentry                                                                                                 
- Distinct from `abctl.Error` which is for help messages                                                                                                       
                                                                                                                                                             
## Motivation                                                                                                                                                   
                                                                                                                                                             
Addresses Sentry issues [ABCTL-A](https://airbytehq.sentry.io/issues/ABCTL-A) and [ABCTL-37](https://airbytehq.sentry.io/issues/ABCTL-37) which account for over 20,000 events from user environment issues that are not actionable bugs.                 
                                                                                                                                                             
## Changes                                                                                                                                                      
                                                                                                                                                             
- Added `UntrackedError` type with proper error wrapping                                                                                                       
- Updated `handleErr` to skip Sentry for UntrackedError                                                                                                        
- Wrapped user environment errors: `ErrDocker`, `ErrPort`, `1ErrAirbyteDir`, `ErrIpAddressForHostFlag`, `ErrInvalidHostFlag`, PG_VERSION read errors                    
                                                                                                                                                             
## Note                                                                                                                                                         
                                                                                                                                                             
Existing users won't benefit until they upgrade. Consider adding Sentry inbound filters for immediate relief:                                                
- `*permission denied*PG_VERSION*`                                                                                                                            
- `*no such file or directory*values.yaml*`