### PR TITLE
ci: add ready_for_review trigger to PR title validation workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - synchronize
+      - ready_for_review
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
## Summary

Adds `ready_for_review` to the list of event types that trigger the PR title validation workflow. This ensures the semantic PR title check runs when a draft PR is marked as ready for review, not just when a PR is opened, edited, or synchronized.

This aligns the workflow with other Airbyte repositories that already have this trigger configured.

## Review & Testing Checklist for Human

- [ ] Confirm this is the desired behavior: PR title validation should run when a draft PR is marked ready for review

### Notes

Requested by @aaronsteers

Link to Devin run: https://app.devin.ai/sessions/9c86b01fddb14dd0a5fd73a4f019c7b2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/abctl/pull/192">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
