### PR TITLE
docs: add instructions for deploying a specific Airbyte version

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,31 @@ Example usage:
 abctl local install --low-resource-mode
 ```
 
+#### Deploying a Specific Airbyte Version
+
+By default, `abctl local install` installs the latest version of Airbyte. To deploy a specific version, create a custom Helm values file and pass it using the `--values` flag.
+
+1. Create an `override_values.yaml` file with the following content (replacing `1.2.0` with your desired version):
+
+   ```yaml
+   global:
+     # Docker image config that will apply to all images.
+     image:
+       # Image tag to use for airbyte images.
+       # Does not include non-airbyte images such as temporal, minio, etc.
+       tag: "1.2.0"
+   ```
+
+2. Install Airbyte using the custom values file:
+
+   ```
+   abctl local install --values override_values.yaml
+   ```
+
+> [!NOTE]
+> The `--values` flag can be used to customize any Airbyte Helm chart values, not just the image tag.
+> See the [Airbyte Helm chart](https://github.com/airbytehq/airbyte-platform/tree/main/charts/airbyte) for all available configuration options.
+
 ### status
 
 ```abctl local status```


### PR DESCRIPTION
# docs: add instructions for deploying a specific Airbyte version

## Summary

Adds a new "Deploying a Specific Airbyte Version" subsection under the `install` command documentation in the README. This documents the workflow of creating an `override_values.yaml` file with a `global.image.tag` override and passing it via `abctl local install --values override_values.yaml`.

## Review & Testing Checklist for Human

- [ ] Verify the YAML structure (`global.image.tag`) is the correct path in the Airbyte Helm chart for overriding image versions
- [ ] Verify the [Airbyte Helm chart link](https://github.com/airbytehq/airbyte-platform/tree/main/charts/airbyte) resolves to a valid page
- [ ] Confirm the note about non-Airbyte images (temporal, minio, etc.) not being affected by this tag is accurate

### Notes
- Requested by @benmoriceau
- [Link to Devin run](https://app.devin.ai/sessions/6e5ec9f942c7446fbb539eb01b584fd6)