### PR TITLE
feat: add abctl PR review skill

### DIFF
--- a/.agents/skills/edge-path-audit/SKILL.md
+++ b/.agents/skills/edge-path-audit/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: edge-path-audit
+description: Adversarially trace abctl failure, retry, cancellation, and cleanup paths. Use before declaring changes complete or when reviewing code that parses CLI/config input, reads or writes files, performs HTTP/auth operations, invokes Docker/Kind/Kubernetes/Helm, mutates Airbyte API resources, runs goroutines or watchers, resolves charts, or changes release automation. Also use when asked what could go wrong, whether a flow fails safely, or whether retries and partial failures are handled.
+---
+
+# Edge Path Audit
+
+Trace each changed operation under adverse conditions instead of stopping after the happy path
+passes. Read [the abctl failure matrix](references/abctl-failure-matrix.md) when the change crosses an
+external boundary.
+
+## Audit method
+
+For every changed function or branch:
+
+1. Name its inputs, durable state, external calls, resources, and outputs.
+2. List read-only operations and mutations in execution order.
+3. At each step, force the next step to fail, time out, or receive cancellation.
+4. Record what state remains and whether retry, cleanup, or recovery is safe.
+5. Search every entry point and caller; a guard on one command path is not a guard on all paths.
+6. Turn meaningful adverse paths into tests or explicitly document why the risk is accepted.
+
+## Required adverse conditions
+
+- Absent, empty, whitespace-only, malformed, semantically contradictory, and unsupported input.
+- Dependency unavailable, unauthorized, permission denied, non-2xx, malformed response, and timeout.
+- Wrong or stale kubeconfig, context, repository index, chart reference, config, cached token, and Git
+  ref.
+- Existing resource, missing resource, update conflict, partial previous attempt, and second attempt.
+- Cancellation immediately before and after each external mutation.
+- Cleanup failure after the primary failure.
+- Oversized input, slow stream, truncated output, and platform-specific path/archive behavior.
+- Concurrent token refresh, watcher shutdown, shared mutable global, and goroutine completion.
+
+## Fail-safe rules
+
+- Perform fallible validation and resolution before mutation when possible.
+- Do not turn a failed guard, lookup, or verification step into success.
+- Preserve the original error and distinguish the failed operation.
+- Do not claim rollback covers resources outside the rollback mechanism.
+- Prefer idempotent create-or-update behavior or explicit recovery over blind replay.
+- Close resources and stop goroutines on every return path.
+
+## Output
+
+Return a compact ledger:
+
+```text
+step -> mutation/state -> forced failure -> remaining state -> retry/cleanup behavior
+```
+
+Identify concrete defects separately with a changed-line anchor, affected workflow, and focused fix.
+Do not report generic hypotheticals without tracing the real path.

--- a/.agents/skills/edge-path-audit/agents/openai.yaml
+++ b/.agents/skills/edge-path-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Edge Path Audit"
+  short_description: "Trace abctl failure, retry, and cleanup paths"
+  default_prompt: "Use $edge-path-audit to trace failure and retry paths in this abctl change."

--- a/.agents/skills/edge-path-audit/references/abctl-failure-matrix.md
+++ b/.agents/skills/edge-path-audit/references/abctl-failure-matrix.md
@@ -1,0 +1,16 @@
+# abctl external-boundary failure matrix
+
+| Boundary | Force these conditions | Check remaining state |
+| --- | --- | --- |
+| CLI and config | missing flag/env, invalid version/URL/path, old config, partial write | preserved prior config, clear error, no mutation |
+| Filesystem | not found, permission denied, symlink, disk full, rename failure | no truncation, readers closed, safe permissions |
+| HTTP and auth | timeout, cancellation, non-2xx, malformed JSON, expired token, refresh failure | body closed, bounded retry, request safely replayed, token not logged |
+| Airbyte API | create succeeds then next step fails, delete fails, duplicate name, wrong org | orphan/duplicate prevention, resource ID retained for recovery |
+| Docker | daemon absent, permission denied, image missing, interrupted stream | reader closed, no false success, platform error surfaced |
+| Kind | existing cluster, create timeout, port collision, delete failure | kubeconfig and cluster state discoverable, retry safe |
+| Kubernetes | AlreadyExists, NotFound, conflict, forbidden, watch closes | correct create/update branch, watcher stopped, no partial secret exposure |
+| Helm repo/chart | index outage, malformed index, prerelease-only, missing chart, bad archive | no prior external mutation, correct V1/V2 routing, actionable error |
+| Helm release | install timeout, Ctrl-C, hook failure, rollback failure | distinguish Helm atomic cleanup from non-Helm resources |
+| Release automation | invalid/existing tag, build/archive failure, tap push failure | no misleading completed release, recovery does not overwrite unrelated refs |
+
+For every retry, name the durable state left by attempt one before declaring attempt two safe.

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: review-pr
+description: Review an abctl GitHub pull request or the current branch for concrete behavioral regressions using diff-first analysis, Go/CLI/Helm/Kubernetes lifecycle lenses, independent specialist passes, and deterministic changed-line validation. Use when asked to review a PR, review a branch or diff, assess whether an abctl change is safe to merge, find bugs in proposed Go code, or produce an approval/request-changes recommendation. This skill is read-only unless the user separately and explicitly authorizes posting or submitting the review.
+---
+
+# Review PR
+
+Review the code that changed, trace the real system path, and report only defects with a concrete
+failure scenario. Optimize for credible P0-P2 findings, not comment volume.
+
+Read the repository `AGENTS.md`, this file, and the following resources completely before reviewing:
+
+- [abctl review lenses](references/abctl-review-lenses.md)
+- [shared review harness](../shared-review-harness/SKILL.md)
+- [edge-path audit](../edge-path-audit/SKILL.md)
+
+## 1. Resolve the review target
+
+- For a PR URL or number, resolve the repository, PR number, base branch, and head SHA. Fetch the PR
+  head into a remote-tracking ref without switching the user's branch.
+- For a current-branch review, determine the upstream base; default to `origin/main` only when no PR
+  base exists.
+- Run `git status --short --branch`. Warn if local changes could contaminate a current-branch review.
+- Record the head SHA. Before any later GitHub mutation, confirm it has not changed.
+
+## 2. Capture an authoritative review bundle
+
+Create a temporary run directory. Capture:
+
+- the unified diff from the base merge-base to the reviewed head;
+- the authoritative changed-file list;
+- the diff stat; and
+- the reviewed base and head SHAs.
+
+For PR mode, prefer `gh pr diff` for the bundle and fetch the head SHA for tracing. For branch mode,
+use `git diff <base>...HEAD`. Include deletions: removing validation, cleanup, or compatibility code can
+introduce the regression.
+
+Do not read the PR body, commit messages, comments, or existing reviews yet. Do not let author intent
+substitute for observed behavior.
+
+## 3. Choose review depth
+
+- If the diff has fewer than 30 changed lines and at most two files, perform one complete pass.
+- Otherwise, use up to three independent specialist agents in one batch when agent slots are
+  available. Give each the raw diff, changed-file list, head SHA, one lens group, and the canonical
+  prompt from the shared harness. The coordinator covers the remaining lens group.
+- If agents are unavailable, perform the same lens groups sequentially.
+- Warn when the diff exceeds roughly 3,000 changed lines; continue, but identify areas that could not
+  be reviewed with high confidence.
+
+Recommended non-trivial lanes:
+
+1. CLI behavior, configuration, auth, and secrets.
+2. External mutations, failure ordering, retry, cancellation, and cleanup.
+3. Helm/chart, Kubernetes/Docker, release portability, and test integrity.
+
+Keep the passes independent. Do not tell a specialist about another reviewer's suspected bug.
+
+## 4. Trace beyond the diff without losing scope
+
+Reviewers may inspect unchanged callers, implementations, interfaces, tests, and dependency types
+when necessary to prove behavior. Use repository search for every changed public function, interface,
+struct field, flag, constant, version classifier, and mutation helper.
+
+Do not report pre-existing problems found during tracing. Anchor the finding to the changed line or
+deletion that makes the real caller fail. Use `causal_diff_quote` when the visible failure sits on an
+unchanged line.
+
+For behavior governed by Helm, Kind, Kubernetes, Docker, Go, or an Airbyte API, verify uncertain
+claims against primary documentation, source, types, a real chart, or a controlled command. Label
+inference as inference.
+
+## 5. Validate and synthesize findings
+
+Require every pass to emit the shared harness JSON sentinel block. Run:
+
+```bash
+python3 .agents/skills/shared-review-harness/scripts/extract_findings.py \
+  --agent-response-files <response-files...> \
+  --output <findings.json>
+
+python3 .agents/skills/shared-review-harness/scripts/validate_findings.py \
+  <diff.patch> <findings.json> > <validated.json>
+```
+
+Independently verify each `anchored` and `causal` finding against the real code path. Keep
+`needs_review` separate and exclude it from the verdict unless manually verified. Any extraction
+failure makes the review incomplete.
+
+After the blind pass, read the PR description, status checks, and existing review discussion. Use
+them to reconcile intended behavior, test claims, and duplicates—not to erase a demonstrated bug.
+
+## 6. Report the result
+
+Lead with findings ordered by severity. For each finding include:
+
+- `[P0]`, `[P1]`, or `[P2]` and a short title;
+- changed file and line;
+- the concrete failure scenario and affected workflow;
+- why the diff causes it;
+- a focused fix direction; and
+- confidence: `VERIFIED` or `LIKELY`.
+
+Use these verdicts:
+
+- Any P0/P1: `REQUEST CHANGES`.
+- Only P2: `APPROVE WITH FINDINGS`.
+- No P0-P2: `APPROVE`.
+- Extraction failure or materially incomplete coverage: `REVIEW INCOMPLETE`.
+
+Mention verification evidence and meaningful gaps. Do not manufacture praise or low-value nits.
+
+The skill is read-only. Do not post inline comments, submit a review, approve, request changes, edit
+code, or create follow-up work unless the user explicitly asks for that separate action. When asked
+to post, show the exact draft and proposed review event before mutating GitHub.

--- a/.agents/skills/review-pr/agents/openai.yaml
+++ b/.agents/skills/review-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review PR"
+  short_description: "Review abctl pull requests for concrete defects"
+  default_prompt: "Use $review-pr to review this abctl pull request for concrete regressions."

--- a/.agents/skills/review-pr/references/abctl-review-lenses.md
+++ b/.agents/skills/review-pr/references/abctl-review-lenses.md
@@ -1,0 +1,107 @@
+# abctl PR review lenses
+
+Apply only the lenses relevant to the changed files, but always perform caller census, behavior
+parity, failure ordering, and test falsification.
+
+## Caller and contract census
+
+For each changed function signature, interface method, struct field, flag, constant, version helper,
+configuration shape, chart value, or output field:
+
+1. Search every caller and consumer.
+2. Distinguish real uses from tests, generated mocks, and same-named symbols.
+3. Verify unchanged callers still satisfy the new contract.
+4. Check both command entry points when behavior is shared by `abctl` and `airbox`.
+5. Anchor any stale-caller finding to the changed producer or contract line.
+
+## CLI behavior and compatibility
+
+- Kong flag tags: defaults, XOR groups, required/existing-file constraints, hidden flags, env vars.
+- Validation before mutation: versions, URLs, host/port, paths, values, secret files, organization and
+  region selection.
+- Error and exit behavior: actionable context, preserved causes, cancellation, no false success.
+- Output compatibility: JSON/YAML fields, credentials output, status text used by scripts.
+- Configuration compatibility: current context, credentials, auth provider, unknown/older config.
+- Repeated invocation: install over existing state, uninstall then reinstall, login refresh, switching
+  organizations, rerunning after partial failure.
+
+## External mutation and lifecycle ledger
+
+List every mutation in order across:
+
+- local config and credential files;
+- Docker images and containers;
+- Kind clusters and kubeconfig;
+- Kubernetes namespaces, volumes, claims, Secrets, ConfigMaps, Services, and Ingresses;
+- Helm repositories and releases; and
+- Airbyte regions and dataplane records.
+
+After each mutation, trace failure of the next operation. Check cleanup, recovery instructions,
+idempotency, name reuse, retry behavior, and whether the user can safely rerun. Confirm validation and
+read-only network resolution happen before mutations when possible. Treat `Atomic` as Helm-release
+cleanup only.
+
+Check context propagation, bounded waits, Ctrl-C, goroutine/watcher shutdown, and resource closure.
+
+## Helm and chart contracts
+
+- Empty, explicit, malformed, missing, prerelease, and `v`-prefixed versions.
+- Stable latest-version selection and repository-index ordering.
+- V1/V2 repository routing and warnings using the same classification.
+- Relative versus absolute chart URLs and URL escaping.
+- Local path and direct URL metadata resolution.
+- Values schema differences across supported chart generations.
+- Ingress routing, image manifest discovery, chart hook resources, release name, namespace, timeout,
+  wait, and atomic behavior.
+- Repository outage, malformed index, missing entry, multiple URLs, and unavailable archive.
+
+Use real repository indexes, `helm show chart`, `helm show values`, `helm template`, or upstream source
+when the behavior is not guaranteed by code. Do not equate rendering with a working installation.
+
+## Kubernetes, Docker, filesystem, and portability
+
+- Kubernetes AlreadyExists/NotFound/conflict behavior and update resource versions.
+- Namespace and cluster selection; stale or wrong kubeconfig/context.
+- Kind creation/deletion, node image compatibility, port binding, volume mounts, and image loading.
+- Docker daemon absent/unavailable, permissions, platform/architecture, auth, and streaming readers.
+- Files missing, unreadable, permission denied, partially written, symlinked, or platform-specific.
+- Linux/macOS/Windows paths, executable suffixes, archives, permissions, and release artifacts.
+
+## Authentication, secrets, and HTTP
+
+- Token refresh serialization, retry count, request replay, and refresh failure.
+- Response status, body closure, decode errors, timeouts, and context cancellation.
+- API base URL joining and path/query escaping.
+- Config file permissions and preservation of unrelated contexts/credentials.
+- Secrets or tokens in logs, errors, telemetry, generated values, command output, or fixtures copied
+  into production behavior.
+- External create/delete calls scoped to the intended organization and resource ID.
+
+## Go correctness
+
+- Error wrapping with `%w`; no swallowed or replaced root causes.
+- Goroutine, watcher, timer, response body, file, archive, and lock lifetime.
+- Data races from mutable globals, test seams, caches, or shared authentication state.
+- Nil/empty handling at boundaries; zero values with real semantic meaning.
+- Slice/map aliasing, mutation during iteration, and nondeterministic ordering in user output.
+- Timeouts, retry loops, polling intervals, and cancellation-safe blocking calls.
+
+## Test falsification
+
+Ask: what is the simplest broken implementation that still passes these tests?
+
+- Mocks asserting values returned by the same mock are not independent evidence.
+- Verify call order and forbidden later calls after a failure.
+- Cover empty, malformed, absent, conflict, timeout, cancellation, retry, and partial-success paths.
+- When package globals are overridden, restore them with `t.Cleanup` and avoid parallel execution.
+- Confirm tests exercise the correct chart generation, namespace, repository, API path, and platform.
+- State when a real Helm/Kind/Docker/API boundary remains untested.
+
+## Release and CI
+
+- `go.mod` Go version versus CI and release setup versions.
+- Build/test/vet/format claims versus workflows that actually run them.
+- GoReleaser targets, archive names, checksums, tag validation, prerelease behavior, and Homebrew update.
+- Workflow permissions, untrusted interpolation, fork behavior, ref/checkout correctness, and partial
+  release failure after a tag has been created.
+- Generated mocks stay synchronized with interfaces.

--- a/.agents/skills/shared-review-harness/SKILL.md
+++ b/.agents/skills/shared-review-harness/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: shared-review-harness
+description: Provide the structured findings contract and deterministic extraction, changed-line anchoring, causal anchoring, severity, and verdict rules used by abctl's review-pr skill. Use when running or extending the abctl PR review workflow, constructing specialist review prompts, validating reviewer output against a unified diff, or diagnosing REVIEW INCOMPLETE and unvalidated findings.
+---
+
+# Shared Review Harness
+
+Use one findings contract across every review lane. Model output is advisory; the deterministic
+helpers prove only that a finding is tied to the diff, not that its reasoning is correct.
+
+Read these references completely when running or changing the harness:
+
+- [agent prompt template](references/agent-prompt-template.md)
+- [priority rubric](references/priority-rubric.md)
+- [report template](references/report-template.md)
+
+## Pipeline
+
+```text
+review responses -> extract_findings.py -> validate_findings.py -> coordinator verification
+     text              JSON array          anchored/causal/needs_review
+```
+
+## Extract findings
+
+```bash
+python3 scripts/extract_findings.py \
+  --agent-response-files <response...> \
+  --output <findings.json>
+```
+
+The extractor requires exactly one `BEGIN_FINDINGS_JSON` / `END_FINDINGS_JSON` pair per response and
+a JSON array inside it. Missing, duplicate, malformed, empty, or unreadable output becomes an
+`extraction_failed: true` marker. The marker is intentional: it prevents a broken reviewer response
+from silently looking like a clean review.
+
+## Validate findings
+
+```bash
+python3 scripts/validate_findings.py <diff.patch> <findings.json>
+```
+
+The validator emits:
+
+- `anchored`: `diff_quote` matches the cited changed line in the cited file and side;
+- `causal`: `causal_diff_quote` matches a changed line in the cited file when the failure is visible
+  on unchanged code; and
+- `needs_review`: malformed, unanchored, out-of-diff, and extraction-failure entries.
+
+Leading `+` and `-` in quotes enforce the diff side. Quotes without a marker are side-agnostic.
+Whitespace is normalized, but quotes shorter than eight normalized characters do not anchor.
+
+## Coordinator contract
+
+1. Pass the actual diff and exact changed-file list to each reviewer.
+2. Preserve the prompt schema and sentinel lines from the template.
+3. Run extraction and validation before reporting a verdict.
+4. Verify every anchored and causal finding against the real execution path.
+5. Exclude `needs_review` from counts unless the coordinator manually proves and upgrades it.
+6. Return `REVIEW INCOMPLETE` when any extraction failure remains.
+7. Delete temporary review bundles after the review unless the user asks to retain them.
+
+Do not use the validator as a truth oracle. A perfectly anchored false claim is still a false finding.

--- a/.agents/skills/shared-review-harness/agents/openai.yaml
+++ b/.agents/skills/shared-review-harness/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Shared Review Harness"
+  short_description: "Validate and anchor structured review findings"
+  default_prompt: "Use $shared-review-harness to validate structured PR review findings."

--- a/.agents/skills/shared-review-harness/references/agent-prompt-template.md
+++ b/.agents/skills/shared-review-harness/references/agent-prompt-template.md
@@ -1,0 +1,63 @@
+# Specialist review prompt template
+
+Render the placeholders for each review lane. Keep the constitution, output keys, and sentinel lines
+unchanged so the extractor and validator can consume the response.
+
+```text
+You are {AGENT_NAME}, an independent bug-hunter reviewing an abctl code diff.
+
+TASK
+{TASK_ONE_LINER}
+
+FOCUS
+{FOCUS_AREAS}
+
+REVIEW CONSTITUTION
+- Review the supplied diff as if it shipped and caused an incident.
+- Report concrete behavioral defects introduced by changed lines or deletions.
+- Do not report style, naming, formatting, generic maintainability, or speculative risks.
+- A clean diff should produce zero findings. Do not invent a finding to be useful.
+- Trace callers and dependencies when needed, including unchanged files, but anchor every finding to
+  the causal changed line in the supplied diff.
+- For lifecycle, security, auth, retry, cleanup, chart, and compatibility claims, trace one concrete
+  execution path before reporting.
+- State the triggering input, dependency failure, state, or interleaving and the affected user or
+  operator workflow.
+- Use P0-P2 only. Confidence must be VERIFIED or LIKELY.
+- Stay read-only. Do not edit files or post to GitHub.
+
+CHANGED FILES
+{CHANGED_FILES}
+
+REVIEWED HEAD
+{HEAD_SHA}
+
+UNIFIED DIFF
+{DIFF}
+
+OUTPUT
+Write a short prose summary, then exactly one sentinel block. The block must contain a JSON array.
+Use an empty array when there are no findings.
+
+BEGIN_FINDINGS_JSON
+[
+  {
+    "file": "internal/example/file.go",
+    "line": 42,
+    "severity": "P2",
+    "title": "Short imperative title",
+    "issue": "Why the changed code is wrong",
+    "failure_scenario": "Concrete triggering state and affected workflow",
+    "suggestion": "Focused fix direction",
+    "confidence": "VERIFIED",
+    "category": "lifecycle",
+    "diff_quote": "+changed line copied from the diff",
+    "causal_diff_quote": ""
+  }
+]
+END_FINDINGS_JSON
+
+`line` is the new-file line for additions and the old-file line for deletions. Use `diff_quote` when
+the cited line itself changed. When the visible defect is on unchanged code, cite the visible line in
+`line`, leave `diff_quote` empty, and put the causal changed line in `causal_diff_quote`.
+```

--- a/.agents/skills/shared-review-harness/references/priority-rubric.md
+++ b/.agents/skills/shared-review-harness/references/priority-rubric.md
@@ -1,0 +1,33 @@
+# Review priority rubric
+
+Priority describes demonstrated impact, not how strongly the reviewer feels.
+
+## P0 — critical
+
+Immediate widespread harm: credential disclosure, destructive data loss, arbitrary code execution,
+release compromise, or a default core workflow unusable for essentially all users. Request changes.
+
+## P1 — high
+
+Likely serious user or operator failure: broken install/uninstall/auth, durable resource corruption,
+unsafe destructive behavior, chart/API compatibility break, repeatable orphaning with significant
+cleanup, or a release that cannot complete or recover safely. Request changes.
+
+## P2 — medium
+
+A concrete bounded regression: a dependency failure leaves recoverable partial state, an edge input
+misroutes behavior, retry/cancellation is unsafe in a limited path, one supported platform breaks, or
+a test gap demonstrably masks a named product bug. Approve with findings unless the shown blast
+radius warrants P1.
+
+## Not findings
+
+Do not report style, naming, formatting, DRY, comment preferences, generic missing tests, speculative
+hardening, or pre-existing problems. Mention verification limitations separately when useful.
+
+## Confidence
+
+- `VERIFIED`: proven from the diff plus traced code, test, primary source, or controlled reproduction.
+- `LIKELY`: the execution path is concrete, but one external premise could not be directly exercised.
+
+Anything weaker stays out of the actionable findings.

--- a/.agents/skills/shared-review-harness/references/report-template.md
+++ b/.agents/skills/shared-review-harness/references/report-template.md
@@ -1,0 +1,36 @@
+# PR review report template
+
+Lead with actionable findings. Omit empty sections except the verdict and verification.
+
+```markdown
+## Findings
+
+- **[P2] Short title** — `path/file.go:42`
+  Concrete failure scenario, why the diff causes it, affected workflow, and focused fix.
+  Confidence: VERIFIED.
+
+## Verdict
+
+**APPROVE WITH FINDINGS**
+
+One-sentence reason for the verdict.
+
+## Verification
+
+- Checks and controlled commands that actually ran.
+- External contracts or real charts inspected.
+- Material boundaries that remain untested.
+
+## Unvalidated findings
+
+- Entries from `needs_review`, with the reason they could not be anchored or verified.
+```
+
+Verdict rules:
+
+- Extraction failure or materially incomplete coverage: `REVIEW INCOMPLETE`.
+- Any P0/P1: `REQUEST CHANGES`.
+- Only P2: `APPROVE WITH FINDINGS`.
+- No P0-P2: `APPROVE`.
+
+Do not post this report or submit a GitHub review without separate explicit authorization.

--- a/.agents/skills/shared-review-harness/scripts/extract_findings.py
+++ b/.agents/skills/shared-review-harness/scripts/extract_findings.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Extract structured findings from one or more review response files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import tempfile
+from pathlib import Path
+
+
+BEGIN = "BEGIN_FINDINGS_JSON"
+END = "END_FINDINGS_JSON"
+
+
+def agent_name(path: Path) -> str:
+    name = path.stem
+    for prefix in ("review-agent-", "agent-"):
+        if name.startswith(prefix):
+            name = name[len(prefix) :]
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", name) or "unknown"
+
+
+def save_raw(name: str, raw: str) -> str:
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", prefix=f"abctl-review-raw-{name}.", suffix=".txt", delete=False
+    ) as handle:
+        handle.write(raw)
+        return handle.name
+
+
+def failure_marker(name: str, raw: str, reason: str) -> dict[str, object]:
+    raw_path = save_raw(name, raw)
+    return {
+        "file": "__extraction_failure__",
+        "line": 0,
+        "severity": "P0",
+        "title": f"Review output extraction failed for {name}",
+        "issue": reason,
+        "failure_scenario": "A reviewer response could be silently omitted from the verdict.",
+        "suggestion": f"Inspect and re-parse {raw_path}.",
+        "confidence": "VERIFIED",
+        "category": "review_harness",
+        "diff_quote": "",
+        "causal_diff_quote": "",
+        "extraction_failed": True,
+        "raw_response": raw_path,
+    }
+
+
+def extract(path: Path) -> list[dict[str, object]]:
+    name = agent_name(path)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        return [failure_marker(name, f"<source unreadable: {exc!r}>\n", f"Cannot read response: {exc}")]
+
+    lines = raw.replace("\r\n", "\n").replace("\r", "\n").splitlines()
+    starts = [index for index, line in enumerate(lines) if line == BEGIN]
+    ends = [index for index, line in enumerate(lines) if line == END]
+    if len(starts) != 1 or len(ends) != 1 or ends[0] <= starts[0]:
+        return [failure_marker(name, raw, "Expected exactly one ordered findings sentinel pair.")]
+
+    payload = "\n".join(lines[starts[0] + 1 : ends[0]]).strip()
+    if not payload:
+        return [failure_marker(name, raw, "The findings sentinel block is empty.")]
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        return [failure_marker(name, raw, f"The findings block is not valid JSON: {exc}")]
+    if not isinstance(parsed, list):
+        return [failure_marker(name, raw, "The findings block must contain a JSON array.")]
+    if any(not isinstance(item, dict) for item in parsed):
+        return [failure_marker(name, raw, "Every finding must be a JSON object.")]
+    return parsed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--agent-response-files", nargs="+", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    findings: list[dict[str, object]] = []
+    for response in args.agent_response_files:
+        findings.extend(extract(response))
+    try:
+        args.output.write_text(json.dumps(findings, indent=2) + "\n", encoding="utf-8")
+    except OSError as exc:
+        parser.error(f"cannot write {args.output}: {exc}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/shared-review-harness/scripts/test_review_harness.py
+++ b/.agents/skills/shared-review-harness/scripts/test_review_harness.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+class ReviewHarnessTest(unittest.TestCase):
+    def run_script(self, script: str, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT_DIR / script), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_extracts_valid_findings(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            response = root / "review-agent-lifecycle.txt"
+            output = root / "findings.json"
+            finding = {
+                "file": "internal/cmd/install.go",
+                "line": 12,
+                "severity": "P2",
+                "confidence": "VERIFIED",
+            }
+            response.write_text(
+                "summary\nBEGIN_FINDINGS_JSON\n"
+                + json.dumps([finding])
+                + "\nEND_FINDINGS_JSON\n",
+                encoding="utf-8",
+            )
+            result = self.run_script(
+                "extract_findings.py",
+                "--agent-response-files",
+                str(response),
+                "--output",
+                str(output),
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual([finding], json.loads(output.read_text(encoding="utf-8")))
+
+    def test_extraction_failure_remains_visible(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            response = root / "broken.txt"
+            output = root / "findings.json"
+            response.write_text("no sentinels", encoding="utf-8")
+            result = self.run_script(
+                "extract_findings.py",
+                "--agent-response-files",
+                str(response),
+                "--output",
+                str(output),
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            findings = json.loads(output.read_text(encoding="utf-8"))
+            self.assertTrue(findings[0]["extraction_failed"])
+            raw_response = Path(findings[0]["raw_response"])
+            self.assertTrue(raw_response.exists())
+            raw_response.unlink()
+
+    def test_validation_buckets_added_removed_causal_and_unmatched(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            diff = root / "diff.patch"
+            findings = root / "findings.json"
+            diff.write_text(
+                "diff --git a/internal/example.go b/internal/example.go\n"
+                "--- a/internal/example.go\n"
+                "+++ b/internal/example.go\n"
+                "@@ -10,2 +10,2 @@\n"
+                "-oldOperation()\n"
+                "+newOperation()\n"
+                " contextLine()\n",
+                encoding="utf-8",
+            )
+            base = {
+                "file": "internal/example.go",
+                "severity": "P2",
+                "confidence": "VERIFIED",
+                "title": "Example finding",
+                "issue": "The changed operation breaks the example path.",
+                "failure_scenario": "The example command reaches this operation.",
+                "suggestion": "Preserve the old behavior.",
+                "category": "behavior",
+                "diff_quote": "",
+                "causal_diff_quote": "",
+            }
+            values = [
+                {**base, "line": 10, "diff_quote": "+newOperation()"},
+                {**base, "line": 10, "diff_quote": "-oldOperation()"},
+                {**base, "line": 99, "causal_diff_quote": "+newOperation()"},
+                {**base, "line": 10, "diff_quote": "+doesNotExist()"},
+            ]
+            findings.write_text(json.dumps(values), encoding="utf-8")
+            result = self.run_script("validate_findings.py", str(diff), str(findings))
+            self.assertEqual(0, result.returncode, result.stderr)
+            buckets = json.loads(result.stdout)
+            self.assertEqual(2, len(buckets["anchored"]))
+            self.assertEqual(1, len(buckets["causal"]))
+            self.assertEqual(1, len(buckets["needs_review"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/shared-review-harness/scripts/validate_findings.py
+++ b/.agents/skills/shared-review-harness/scripts/validate_findings.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Anchor structured review findings to changed lines in a unified Git diff."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+HUNK = re.compile(r"^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+MIN_QUOTE_LENGTH = 8
+VALID_SEVERITIES = {"P0", "P1", "P2"}
+VALID_CONFIDENCE = {"VERIFIED", "LIKELY"}
+
+
+@dataclass(frozen=True)
+class ChangedLine:
+    number: int
+    side: str
+    content: str
+
+
+@dataclass
+class DiffFile:
+    path: str
+    changed: list[ChangedLine] = field(default_factory=list)
+
+
+def normalize_path(path: str) -> str:
+    path = path.strip()
+    if path.startswith("a/") or path.startswith("b/"):
+        return path[2:]
+    return path
+
+
+def diff_paths(header: str) -> tuple[str, str] | None:
+    try:
+        parts = shlex.split(header)
+    except ValueError:
+        return None
+    if len(parts) < 4 or parts[:2] != ["diff", "--git"]:
+        return None
+    return normalize_path(parts[2]), normalize_path(parts[3])
+
+
+def parse_diff(raw: str) -> dict[str, DiffFile]:
+    files: dict[str, DiffFile] = {}
+    current: DiffFile | None = None
+    old_line = 0
+    new_line = 0
+    in_hunk = False
+
+    for raw_line in raw.splitlines():
+        paths = diff_paths(raw_line)
+        if paths is not None:
+            path = paths[1] if paths[1] != "/dev/null" else paths[0]
+            current = files.setdefault(path, DiffFile(path))
+            in_hunk = False
+            continue
+        match = HUNK.match(raw_line)
+        if match and current is not None:
+            old_line, new_line = map(int, match.groups())
+            in_hunk = True
+            continue
+        if not in_hunk or current is None:
+            continue
+        if raw_line.startswith("\\ No newline at end of file"):
+            continue
+        if raw_line.startswith("+") and not raw_line.startswith("+++"):
+            current.changed.append(ChangedLine(new_line, "added", normalize_text(raw_line[1:])))
+            new_line += 1
+        elif raw_line.startswith("-") and not raw_line.startswith("---"):
+            current.changed.append(ChangedLine(old_line, "removed", normalize_text(raw_line[1:])))
+            old_line += 1
+        elif raw_line.startswith(" "):
+            old_line += 1
+            new_line += 1
+
+    return files
+
+
+def normalize_text(value: str) -> str:
+    return " ".join(value.split())
+
+
+def parse_quote(value: object) -> tuple[str | None, str] | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    side: str | None = None
+    if stripped.startswith("+") and not stripped.startswith("+++"):
+        side = "added"
+        stripped = stripped[1:]
+    elif stripped.startswith("-") and not stripped.startswith("---"):
+        side = "removed"
+        stripped = stripped[1:]
+    normalized = normalize_text(stripped)
+    if len(normalized) < MIN_QUOTE_LENGTH:
+        return None
+    return side, normalized
+
+
+def valid_shape(finding: object) -> bool:
+    if not isinstance(finding, dict):
+        return False
+    line = finding.get("line")
+    string_fields = (
+        "file",
+        "title",
+        "issue",
+        "failure_scenario",
+        "suggestion",
+        "category",
+        "diff_quote",
+        "causal_diff_quote",
+    )
+    return (
+        all(isinstance(finding.get(field), str) for field in string_fields)
+        and isinstance(line, int)
+        and not isinstance(line, bool)
+        and finding.get("severity") in VALID_SEVERITIES
+        and finding.get("confidence") in VALID_CONFIDENCE
+    )
+
+
+def quote_matches(lines: list[ChangedLine], quote: object, line_number: int | None) -> bool:
+    parsed = parse_quote(quote)
+    if parsed is None:
+        return False
+    required_side, text = parsed
+    for changed in lines:
+        if line_number is not None and changed.number != line_number:
+            continue
+        if required_side is not None and changed.side != required_side:
+            continue
+        if text in changed.content:
+            return True
+    return False
+
+
+def validate(diff: dict[str, DiffFile], findings: list[object]) -> dict[str, list[object]]:
+    buckets: dict[str, list[object]] = {"anchored": [], "causal": [], "needs_review": []}
+    for finding in findings:
+        if not valid_shape(finding) or finding.get("extraction_failed") is True:
+            buckets["needs_review"].append(finding)
+            continue
+        path = normalize_path(finding["file"])
+        changed_file = diff.get(path)
+        if changed_file is None:
+            buckets["needs_review"].append(finding)
+            continue
+        if quote_matches(changed_file.changed, finding.get("diff_quote"), finding["line"]):
+            buckets["anchored"].append(finding)
+        elif quote_matches(changed_file.changed, finding.get("causal_diff_quote"), None):
+            buckets["causal"].append(finding)
+        else:
+            buckets["needs_review"].append(finding)
+    return buckets
+
+
+def load_findings(path: Path) -> list[object]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, list):
+        raise ValueError("findings JSON must be an array")
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("diff", type=Path)
+    parser.add_argument("findings", type=Path)
+    args = parser.parse_args()
+    try:
+        parsed_diff = parse_diff(args.diff.read_text(encoding="utf-8"))
+        findings = load_findings(args.findings)
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        print(f"validate_findings: {exc}", file=sys.stderr)
+        return 2
+    result = validate(parsed_diff, findings)
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    print(
+        "validate_findings: "
+        f"{len(findings)} in, {len(result['anchored'])} anchored, "
+        f"{len(result['causal'])} causal, {len(result['needs_review'])} needs review",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,25 @@
+---
+description: Review an abctl PR or current branch with the shared validated review skill
+model: opus
+argument-hint: "[pr-url|pr-number]"
+---
+
+# Review PR
+
+Use the canonical skill exposed at `.claude/skills/review-pr/SKILL.md` and follow it completely.
+
+<arguments>
+$ARGUMENTS
+</arguments>
+
+Treat a PR URL or number as the review target. When arguments are empty, review the current branch
+against its resolved upstream base.
+
+Claude-specific orchestration:
+
+- Use up to three independent Agent tasks for a non-trivial diff when slots are available.
+- Keep the lanes blind and independent; pass each the actual diff, changed-file list, head SHA, and
+  canonical prompt contract.
+- Run the extraction and validation helpers through `.claude/skills/shared-review-harness/scripts/`.
+- Return the report in conversation. Do not post comments or submit a GitHub review unless the user
+  explicitly authorizes that separate mutation.

--- a/.claude/skills/edge-path-audit
+++ b/.claude/skills/edge-path-audit
@@ -1,0 +1,1 @@
+../../.agents/skills/edge-path-audit

--- a/.claude/skills/review-pr
+++ b/.claude/skills/review-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/review-pr

--- a/.claude/skills/shared-review-harness
+++ b/.claude/skills/shared-review-harness
@@ -1,0 +1,1 @@
+../../.agents/skills/shared-review-harness

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,97 @@
+# AGENTS.md — abctl engineering and review standards
+
+These instructions apply to the entire repository. `abctl` is a Go CLI that orchestrates
+Docker, Kind, Kubernetes, Helm, local files, browsers, and authenticated Airbyte APIs. Review
+and implementation work must treat those boundaries as real stateful systems, not as ordinary
+in-process helpers.
+
+## Scope and change discipline
+
+- Keep each change focused on the requested behavior. Do not mix opportunistic refactors with a
+  feature or fix.
+- Prefer the smallest diff that solves the problem and preserves existing CLI behavior.
+- Treat command flags, output formats, configuration files, chart values, and persisted Kubernetes
+  resources as compatibility contracts.
+- Do not hand-edit generated mocks under `internal/**/mock/` or other files carrying generated-code
+  headers. Update the source interface and run `make mocks`.
+
+## Stateful operation safety
+
+- Validate and resolve all inputs that can fail without side effects before creating or mutating
+  external resources.
+- For flows that touch more than one system, write down the mutation order. After every mutation,
+  ask what remains if the next step fails, times out, or is cancelled.
+- Make retries and repeated invocations safe. Detect existing Kind clusters, Helm releases,
+  Kubernetes resources, configuration, and Airbyte API records before blindly creating duplicates.
+- Add cleanup or a clear recovery path for partial state. Helm `Atomic` protects the Helm release;
+  it does not clean up Kind clusters, API records, files, or resources created outside Helm.
+- Propagate `context.Context` through network, Kubernetes, Docker, and long-running operations.
+  Preserve cancellation and use bounded waits where the dependency can hang.
+
+## Helm and chart compatibility
+
+- Preserve V1/V2 chart routing deliberately. Repository choice, warning behavior, values generation,
+  ingress routing, and image discovery must classify versions consistently, including prereleases.
+- Treat chart names, versions, repository URLs, metadata, and values schemas as external contracts.
+  Verify uncertain behavior against the actual chart or repository index rather than inferring it.
+- Default-version resolution must select a stable release and fail clearly when the repository is
+  unavailable, malformed, or missing the expected chart.
+- When changing generated values, verify both relevant chart generations and distinguish
+  `helm template` success from an end-to-end working installation.
+
+## Secrets, authentication, and configuration
+
+- Never log access tokens, refresh tokens, client secrets, passwords, Docker credentials, or raw
+  Kubernetes Secret data.
+- Preserve authentication retry and refresh semantics, including request-body replay and concurrent
+  refresh behavior.
+- Treat configuration writes as durable state: retain unrelated contexts and credentials, use safe
+  file permissions, and avoid leaving truncated files after a failed write.
+- Validate user-supplied paths, URLs, versions, hosts, ports, values, and secret files at the CLI or
+  I/O boundary before downstream mutation.
+
+## Go correctness
+
+- Close response bodies, files, archive readers, watchers, and other resources on every path.
+- Do not leak goroutines or watchers after command completion, cancellation, or early return.
+- Wrap errors with actionable operation context while preserving the original cause with `%w`.
+- Avoid package-level mutable test seams when parallel tests can race. Restore overridden globals
+  with `t.Cleanup` and do not mark those tests parallel.
+- Keep Linux, macOS, and Windows behavior in mind for paths, permissions, archives, executables, and
+  release artifacts.
+
+## Test integrity
+
+- Test the behavioral contract, not values copied from the mock setup.
+- Cover empty, malformed, absent, error, timeout/cancellation, retry, and partial-success paths when
+  they are relevant to the changed behavior.
+- For mutation flows, assert call ordering and assert that later calls do not occur after failure.
+- A mocked Helm/Kubernetes/API unit test does not prove a real chart can be fetched, rendered, or
+  installed. State that boundary explicitly and add focused integration evidence when risk warrants.
+
+## Verification
+
+Use the narrowest relevant checks while iterating, then run the repository checks before declaring
+the work complete:
+
+```bash
+make fmt
+make build
+make test
+make vet
+git diff --check
+```
+
+CI currently runs `make build` and `make test` on Linux. Do not claim that CI covers vet, the race
+detector, real Kind/Helm installation, or the release platform matrix unless the workflow changes.
+
+## Pull-request reviews
+
+- Use `.agents/skills/review-pr/SKILL.md` for PR or branch reviews.
+- Review the authoritative diff independently before reading the PR description, commits, or review
+  discussion. Reconcile that metadata only after the initial bug hunt.
+- Report only concrete defects introduced by changed lines or deletions. Inspect unchanged callers
+  and dependencies when needed, but anchor every actionable finding to the causal diff.
+- P0/P1 findings block approval. P2 findings are non-blocking unless their demonstrated blast radius
+  warrants promotion. Style-only observations are not findings.
+- Never post comments, approve, or request changes without the user's explicit authorization.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,10 @@ detector, real Kind/Helm installation, or the release platform matrix unless the
 ## Pull-request reviews
 
 - Use `.agents/skills/review-pr/SKILL.md` for PR or branch reviews.
+- Treat `.agents/skills/` as the canonical, agent-neutral skill source. Entries under
+  `.claude/skills/` are symlinks to the canonical skills; do not create divergent copies there.
+- Keep Claude-only slash commands, model choices, hooks, and settings under `.claude/` so Claude can
+  have specialized ergonomics without changing the shared skill contract.
 - Review the authoritative diff independently before reading the PR description, commits, or review
   discussion. Reconcile that metadata only after the initial bug hunt.
 - Report only concrete defects introduced by changed lines or deletions. Inspect unchanged callers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## What

- add repository-wide `AGENTS.md` standards for abctl engineering and review work
- add a repo-local `review-pr` skill tailored to Go CLI, Helm, Kubernetes, Docker, auth, lifecycle, test-integrity, and release risks
- add a shared structured findings harness with deterministic extraction and changed-line/causal validation
- add an `edge-path-audit` skill for failure, retry, cancellation, and cleanup tracing
- expose the canonical `.agents/skills` packages to Claude through Git-tracked `.claude/skills` symlinks
- add a Claude-only `/review-pr` command using Opus while keeping the shared workflow agent-neutral

## Why

`abctl` coordinates several stateful external systems. A tailored review workflow makes failure ordering, partial state, chart compatibility, secret handling, and retry safety first-class review concerns while keeping reviews diff-scoped and read-only by default.

`.agents/skills` remains the canonical source for every agent. Claude gets symlinked discovery plus its own command and model configuration under `.claude/`, without duplicating or drifting the shared skills.

## Validation

- `python3 .agents/skills/shared-review-harness/scripts/test_review_harness.py`
- the same harness tests pass through `.claude/skills/shared-review-harness`
- all three skills pass `quick_validate.py` through both canonical and Claude symlink paths
- symlinks are stored by Git with mode `120000` and resolve to `../../.agents/skills/*`
- blind forward test against PR #199 produced correctly anchored P2 lifecycle findings
- `git diff --cached --check`